### PR TITLE
feat: add settings navigation button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENT GUIDELINES
+- Do not start dev servers/watchers (Expo/Metro) during edits.
+- Use `npm ci` (not `npm install`).
+- Keep diffs small; avoid formatting rewrites.
+- Don’t edit lockfiles unless adding/removing deps.
+- If scripts must change, add a TEMP comment and keep them no‑op.
+- Output: summary of changed files and test commands to run.

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,5 @@
-import { Text, View } from "react-native";
+import { Button, Text, View } from "react-native";
+import { router } from "expo-router";
 
 export default function Index() {
   return (
@@ -10,6 +11,11 @@ export default function Index() {
       }}
     >
       <Text>Edit app/index.tsx to edit this screen.</Text>
+      <View style={{ height: 16 }} />
+      <Button
+        title="Go to Settings"
+        onPress={() => router.push("/settings")}
+      />
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add repository AGENTS.md with development guidelines
- add button on main app page that navigates to settings

## Testing
- `npm ci`
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d4883a948328a9926f914401e916