### PR TITLE
feat: manage expense categories

### DIFF
--- a/__tests__/entities.test.ts
+++ b/__tests__/entities.test.ts
@@ -62,6 +62,10 @@ import {
   listBankAccounts,
   listEntities,
   updateBankAccount,
+  createExpenseCategory,
+  updateExpenseCategory,
+  deleteExpenseCategory,
+  listExpenseCategories,
 } from '../lib/entities';
 import { initDb } from '../lib/db';
 const sqlite = require('expo-sqlite');
@@ -87,4 +91,33 @@ test('create, update, delete bank account', async () => {
   await deleteBankAccount(created.id);
   const list = await listBankAccounts();
   expect(list.length).toBe(0);
+});
+
+test('create, update, delete expense category with parent', async () => {
+  const parent = await createExpenseCategory({
+    label: 'Parent',
+    prompt: 'p',
+    parentId: null,
+  });
+  const child = await createExpenseCategory({
+    label: 'Child',
+    prompt: 'p',
+    parentId: parent.id,
+  });
+  let list = await listExpenseCategories();
+  expect(list.find((c) => c.id === child.id)?.parentId).toBe(parent.id);
+  await updateExpenseCategory(child.id, {
+    label: 'Child2',
+    prompt: 'p2',
+    parentId: null,
+  });
+  list = await listExpenseCategories();
+  const updatedChild = list.find((c) => c.id === child.id);
+  expect(updatedChild?.label).toBe('Child2');
+  expect(updatedChild?.parentId).toBeNull();
+  await deleteExpenseCategory(child.id);
+  await deleteExpenseCategory(parent.id);
+  list = await listExpenseCategories();
+  expect(list.find((c) => c.id === parent.id)).toBeFalsy();
+  expect(list.find((c) => c.id === child.id)).toBeFalsy();
 });

--- a/app/expense-categories/index.tsx
+++ b/app/expense-categories/index.tsx
@@ -1,0 +1,255 @@
+import { useCallback, useState } from 'react';
+import {
+  Alert,
+  Button,
+  FlatList,
+  Modal,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+import {
+  ExpenseCategory,
+  ExpenseCategoryInput,
+  expenseCategorySchema,
+  listExpenseCategories,
+  createExpenseCategory,
+  updateExpenseCategory,
+  deleteExpenseCategory,
+} from '../../lib/entities';
+
+function buildChildrenMap(list: ExpenseCategory[]) {
+  const map = new Map<string | null, ExpenseCategory[]>();
+  for (const item of list) {
+    const arr = map.get(item.parentId) || [];
+    arr.push(item);
+    map.set(item.parentId, arr);
+  }
+  return map;
+}
+
+function buildTree(list: ExpenseCategory[]) {
+  const map = buildChildrenMap(list);
+  const result: { item: ExpenseCategory; depth: number }[] = [];
+  function walk(parentId: string | null, depth: number) {
+    const children = map.get(parentId) || [];
+    children.sort((a, b) => a.label.localeCompare(b.label));
+    for (const child of children) {
+      result.push({ item: child, depth });
+      walk(child.id, depth + 1);
+    }
+  }
+  walk(null, 0);
+  return result;
+}
+
+function collectDescendants(
+  id: string,
+  map: Map<string | null, ExpenseCategory[]>,
+  set: Set<string>
+) {
+  const children = map.get(id) || [];
+  for (const child of children) {
+    set.add(child.id);
+    collectDescendants(child.id, map, set);
+  }
+}
+
+export default function ExpenseCategoriesPage() {
+  const [categories, setCategories] = useState<ExpenseCategory[]>([]);
+  const [label, setLabel] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [parentId, setParentId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [error, setError] = useState('');
+  const [parentVisible, setParentVisible] = useState(false);
+
+  const load = useCallback(async () => {
+    const data = await listExpenseCategories();
+    setCategories(data);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load])
+  );
+
+  const resetForm = () => {
+    setLabel('');
+    setPrompt('');
+    setParentId(null);
+    setEditingId(null);
+    setError('');
+  };
+
+  const handleSubmit = async () => {
+    const input: ExpenseCategoryInput = {
+      label: label.trim(),
+      prompt: prompt.trim(),
+      parentId,
+    };
+    const parsed = expenseCategorySchema.safeParse(input);
+    if (!parsed.success) {
+      setError(parsed.error.issues[0].message);
+      return;
+    }
+    setError('');
+    if (editingId) {
+      await updateExpenseCategory(editingId, parsed.data);
+    } else {
+      await createExpenseCategory(parsed.data);
+    }
+    resetForm();
+    load();
+  };
+
+  const handleEdit = (item: ExpenseCategory) => {
+    setEditingId(item.id);
+    setLabel(item.label);
+    setPrompt(item.prompt);
+    setParentId(item.parentId);
+  };
+
+  const confirmDelete = (id: string) => {
+    Alert.alert('Delete category?', 'Are you sure?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          await deleteExpenseCategory(id);
+          if (editingId === id) resetForm();
+          load();
+        },
+      },
+    ]);
+  };
+
+  const tree = buildTree(categories);
+
+  const childrenMap = buildChildrenMap(categories);
+  const invalidIds = new Set<string>();
+  if (editingId) {
+    invalidIds.add(editingId);
+    collectDescendants(editingId, childrenMap, invalidIds);
+  }
+  const parentOptions = buildTree(categories.filter((c) => !invalidIds.has(c.id)));
+
+  const selectedParent = categories.find((c) => c.id === parentId) || null;
+
+  const renderItem = ({
+    item,
+  }: {
+    item: { item: ExpenseCategory; depth: number };
+  }) => (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        padding: 16,
+        borderBottomWidth: 1,
+      }}
+    >
+      <TouchableOpacity
+        style={{ flex: 1, paddingLeft: item.depth * 16 }}
+        onPress={() => handleEdit(item.item)}
+      >
+        <Text style={{ fontSize: 16 }}>{item.item.label}</Text>
+      </TouchableOpacity>
+      <Button title="Delete" onPress={() => confirmDelete(item.item.id)} />
+    </View>
+  );
+
+  return (
+    <View style={{ flex: 1 }}>
+      <View style={{ padding: 16, borderBottomWidth: 1 }}>
+        <Text style={{ marginBottom: 4 }}>Label</Text>
+        <TextInput
+          value={label}
+          onChangeText={setLabel}
+          style={{ borderWidth: 1, padding: 8, marginBottom: 12 }}
+        />
+        <Text style={{ marginBottom: 4 }}>Prompt</Text>
+        <TextInput
+          value={prompt}
+          onChangeText={setPrompt}
+          multiline
+          style={{ borderWidth: 1, padding: 8, height: 80, marginBottom: 12 }}
+        />
+        <Text style={{ marginBottom: 4 }}>Parent</Text>
+        <TouchableOpacity
+          onPress={() => setParentVisible(true)}
+          style={{ borderWidth: 1, padding: 8, marginBottom: 12 }}
+        >
+          <Text>{selectedParent ? selectedParent.label : 'None'}</Text>
+        </TouchableOpacity>
+        {error ? <Text style={{ color: 'red', marginBottom: 12 }}>{error}</Text> : null}
+        <Button
+          title={editingId ? 'Update Category' : 'Add Category'}
+          onPress={handleSubmit}
+        />
+        {editingId ? (
+          <View style={{ marginTop: 8 }}>
+            <Button title="Cancel" onPress={resetForm} />
+          </View>
+        ) : null}
+      </View>
+      <FlatList
+        data={tree}
+        keyExtractor={(i) => i.item.id}
+        renderItem={renderItem}
+      />
+      <Modal visible={parentVisible} transparent animationType="fade">
+        <View
+          style={{
+            flex: 1,
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            justifyContent: 'center',
+          }}
+        >
+          <View
+            style={{
+              backgroundColor: 'white',
+              margin: 32,
+              padding: 16,
+              maxHeight: '80%',
+            }}
+          >
+            <FlatList
+              data={[{ item: null, depth: 0 }, ...parentOptions]}
+              keyExtractor={(i, idx) => (i.item ? i.item.id : 'none') + idx}
+              renderItem={({ item }) =>
+                item.item ? (
+                  <TouchableOpacity
+                    style={{ padding: 8, paddingLeft: item.depth * 16 }}
+                    onPress={() => {
+                      setParentId(item.item!.id);
+                      setParentVisible(false);
+                    }}
+                  >
+                    <Text>{item.item.label}</Text>
+                  </TouchableOpacity>
+                ) : (
+                  <TouchableOpacity
+                    style={{ padding: 8 }}
+                    onPress={() => {
+                      setParentId(null);
+                      setParentVisible(false);
+                    }}
+                  >
+                    <Text>None</Text>
+                  </TouchableOpacity>
+                )
+              }
+            />
+            <Button title="Close" onPress={() => setParentVisible(false)} />
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}
+

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -18,6 +18,11 @@ export default function Index() {
       />
       <View style={{ height: 16 }} />
       <Button
+        title="Expense Categories"
+        onPress={() => router.push("/expense-categories")}
+      />
+      <View style={{ height: 16 }} />
+      <Button
         title="Go to Settings"
         onPress={() => router.push("/settings")}
       />

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -14,6 +14,7 @@ export interface Entity {
 }
 
 export type BankAccount = Entity;
+export type ExpenseCategory = Entity;
 
 export const entitySchema = z.object({
   label: z.string().min(1, 'Label is required'),
@@ -26,6 +27,13 @@ export type EntityInput = z.infer<typeof entitySchema>;
 
 export const bankAccountSchema = entitySchema.pick({ label: true, prompt: true });
 export type BankAccountInput = z.infer<typeof bankAccountSchema>;
+
+export const expenseCategorySchema = entitySchema.pick({
+  label: true,
+  prompt: true,
+  parentId: true,
+});
+export type ExpenseCategoryInput = z.infer<typeof expenseCategorySchema>;
 
 function mapRow(row: any): Entity {
   return {
@@ -130,5 +138,26 @@ export async function updateBankAccount(id: string, input: BankAccountInput) {
 }
 
 export async function deleteBankAccount(id: string) {
+  return deleteEntity(id);
+}
+
+export async function listExpenseCategories() {
+  return listEntities('expense');
+}
+
+export async function createExpenseCategory(input: ExpenseCategoryInput) {
+  const parsed = expenseCategorySchema.parse(input);
+  return createEntity({ ...parsed, category: 'expense' });
+}
+
+export async function updateExpenseCategory(
+  id: string,
+  input: ExpenseCategoryInput
+) {
+  const parsed = expenseCategorySchema.parse(input);
+  return updateEntity(id, { ...parsed, category: 'expense' });
+}
+
+export async function deleteExpenseCategory(id: string) {
   return deleteEntity(id);
 }


### PR DESCRIPTION
## Summary
- add entity helpers for expense categories
- manage expense categories with parent selection
- test expense category CRUD

## Testing
- `npx jest __tests__/entities.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2df7236f483289ff451d8e441c55c