### PR TITLE
feat: add statements and transactions

### DIFF
--- a/__tests__/statements.test.ts
+++ b/__tests__/statements.test.ts
@@ -1,0 +1,63 @@
+jest.mock('expo-sqlite', () => require('../test-utils/sqliteMock').sqliteMock);
+
+import { initDb } from '../lib/db';
+import { createBankAccount } from '../lib/entities';
+import {
+  createStatement,
+  listStatementsWithMeta,
+} from '../lib/statements';
+import { createTransaction } from '../lib/transactions';
+const sqlite = require('expo-sqlite');
+
+beforeEach(async () => {
+  sqlite.__reset();
+  await initDb();
+});
+
+test('statement listing shows transaction count and bank label', async () => {
+  const bank = await createBankAccount({
+    label: 'Bank',
+    prompt: 'p',
+    currency: 'USD',
+  });
+  const stmt = await createStatement({
+    bankId: bank.id,
+    uploadDate: 1,
+    status: 'new',
+  });
+  await createTransaction({
+    statementId: stmt.id,
+    createdAt: 1,
+    amount: 100,
+    currency: 'USD',
+    shared: false,
+  });
+  await createTransaction({
+    statementId: stmt.id,
+    createdAt: 2,
+    amount: 200,
+    currency: 'USD',
+    shared: false,
+  });
+  const statements = await listStatementsWithMeta();
+  expect(statements[0].transactionCount).toBe(2);
+  expect(statements[0].bankLabel).toBe('Bank');
+});
+
+test('reject negative transaction amount', async () => {
+  const bank = await createBankAccount({
+    label: 'B',
+    prompt: 'p',
+    currency: 'USD',
+  });
+  const stmt = await createStatement({ bankId: bank.id, uploadDate: 1, status: 'new' });
+  await expect(
+    createTransaction({
+      statementId: stmt.id,
+      createdAt: 1,
+      amount: -5,
+      currency: 'USD',
+      shared: false,
+    })
+  ).rejects.toThrow();
+});

--- a/app/bank-accounts/[id].tsx
+++ b/app/bank-accounts/[id].tsx
@@ -6,7 +6,7 @@ import BankAccountForm from './form';
 export default function EditBankAccount() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [initial, setInitial] =
-    useState<{ label: string; prompt: string } | null>(null);
+    useState<{ label: string; prompt: string; currency: string } | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -15,6 +15,7 @@ export default function EditBankAccount() {
         setInitial({
           label: acct.label,
           prompt: acct.prompt,
+          currency: acct.currency,
         });
       }
     })();

--- a/app/bank-accounts/form.tsx
+++ b/app/bank-accounts/form.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { Button, Text, TextInput, View } from 'react-native';
 import { BankAccountInput, bankAccountSchema } from '../../lib/entities';
+import { SUPPORTED_CURRENCIES } from '../../lib/currencies';
 
 export type Props = {
-  initial?: { label: string; prompt: string };
+  initial?: { label: string; prompt: string; currency: string };
   onSubmit: (input: BankAccountInput) => Promise<void>;
   submitLabel: string;
 };
@@ -11,12 +12,16 @@ export type Props = {
 export default function BankAccountForm({ initial, onSubmit, submitLabel }: Props) {
   const [label, setLabel] = useState<string>(initial?.label ?? '');
   const [prompt, setPrompt] = useState<string>(initial?.prompt ?? '');
+  const [currency, setCurrency] = useState<string>(
+    initial?.currency ?? SUPPORTED_CURRENCIES[2]
+  );
   const [error, setError] = useState<string>('');
 
   const handleSave = async () => {
     const input: BankAccountInput = {
       label: label.trim(),
       prompt: prompt.trim(),
+      currency: currency as any,
     };
     const result = bankAccountSchema.safeParse(input);
     if (!result.success) {
@@ -41,6 +46,13 @@ export default function BankAccountForm({ initial, onSubmit, submitLabel }: Prop
         onChangeText={setPrompt}
         multiline
         style={{ borderWidth: 1, padding: 8, height: 120, marginBottom: 12 }}
+      />
+      <Text style={{ marginBottom: 4 }}>Currency</Text>
+      <TextInput
+        value={currency}
+        onChangeText={setCurrency}
+        autoCapitalize="characters"
+        style={{ borderWidth: 1, padding: 8, marginBottom: 12 }}
       />
       {error ? <Text style={{ color: 'red', marginBottom: 12 }}>{error}</Text> : null}
       <Button title={submitLabel} onPress={handleSave} />

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,30 +1,57 @@
-import { Button, Text, View } from "react-native";
-import { router } from "expo-router";
+import { useEffect, useState } from 'react';
+import { FlatList, Text, View } from 'react-native';
+import { listStatementsWithMeta, StatementMeta } from '../lib/statements';
+
+function StatusRow({ item }: { item: StatementMeta }) {
+  const statuses = [
+    { checked: true },
+    { checked: item.processedAt !== null },
+    { checked: item.reviewedAt !== null },
+    { checked: item.publishedAt !== null },
+  ];
+  return (
+    <View style={{ flexDirection: 'row', width: 80, justifyContent: 'space-between' }}>
+      {statuses.map((s, i) => (
+        <Text key={i}>{s.checked ? '[x]' : '[ ]'}</Text>
+      ))}
+    </View>
+  );
+}
 
 export default function Index() {
+  const [statements, setStatements] = useState<StatementMeta[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const list = await listStatementsWithMeta();
+      setStatements(list);
+    })();
+  }, []);
+
   return (
-    <View
-      style={{
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-      }}
-    >
-      <Text>Edit app/index.tsx to edit this screen.</Text>
-      <View style={{ height: 16 }} />
-      <Button
-        title="Bank accounts"
-        onPress={() => router.push("/bank-accounts")}
-      />
-      <View style={{ height: 16 }} />
-      <Button
-        title="Expense Categories"
-        onPress={() => router.push("/expense-categories")}
-      />
-      <View style={{ height: 16 }} />
-      <Button
-        title="Go to Settings"
-        onPress={() => router.push("/settings")}
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={statements}
+        keyExtractor={(s) => s.id}
+        ListEmptyComponent={<Text>No statements</Text>}
+        renderItem={({ item }) => (
+          <View
+            style={{
+              flexDirection: 'row',
+              paddingVertical: 8,
+              borderBottomWidth: 1,
+            }}
+          >
+            <Text style={{ flex: 1 }}>{item.bankLabel}</Text>
+            <Text style={{ flex: 1 }}>
+              {new Date(item.uploadDate).toLocaleDateString()}
+            </Text>
+            <Text style={{ width: 40, textAlign: 'center' }}>
+              {item.transactionCount}
+            </Text>
+            <StatusRow item={item} />
+          </View>
+        )}
       />
     </View>
   );

--- a/lib/currencies.ts
+++ b/lib/currencies.ts
@@ -1,0 +1,14 @@
+export const SUPPORTED_CURRENCIES = [
+  'EUR',
+  'CHF',
+  'USD',
+  'BRL',
+  'GBP',
+  'JPY',
+  'CAD',
+  'AUD',
+  'CNY',
+  'SEK',
+] as const;
+
+export type Currency = (typeof SUPPORTED_CURRENCIES)[number];

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -16,10 +16,40 @@ export async function initDb() {
       category TEXT NOT NULL,
       prompt TEXT NOT NULL,
       parent_id INTEGER,
+      currency TEXT NOT NULL,
       created_at INTEGER,
       updated_at INTEGER
     );
-    CREATE INDEX IF NOT EXISTS idx_entities_label ON entities(label);`
+    CREATE INDEX IF NOT EXISTS idx_entities_label ON entities(label);
+    CREATE TABLE IF NOT EXISTS statements(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      bank_id INTEGER NOT NULL,
+      upload_date INTEGER NOT NULL,
+      file TEXT,
+      external_file_id TEXT,
+      status TEXT NOT NULL DEFAULT 'new',
+      processed_at INTEGER,
+      reviewed_at INTEGER,
+      published_at INTEGER,
+      archived_at INTEGER
+    );
+    CREATE INDEX IF NOT EXISTS idx_statements_upload_date ON statements(upload_date);
+    CREATE TABLE IF NOT EXISTS transactions(
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      statement_id INTEGER NOT NULL,
+      recipient_id INTEGER,
+      sender_id INTEGER,
+      created_at INTEGER NOT NULL,
+      processed_at INTEGER,
+      archived_at INTEGER,
+      location TEXT,
+      amount INTEGER NOT NULL,
+      currency TEXT NOT NULL,
+      reviewed_at INTEGER,
+      shared INTEGER NOT NULL DEFAULT 0,
+      shared_amount REAL
+    );
+    CREATE INDEX IF NOT EXISTS idx_transactions_statement ON transactions(statement_id);`
   );
   await seedDefaultCategories(db);
 }
@@ -33,11 +63,12 @@ async function seedDefaultCategories(db: SQLite.SQLiteDatabase) {
   const now = Date.now();
   for (const cat of DEFAULT_EXPENSE_CATEGORIES) {
     await db.runAsync(
-      'INSERT INTO entities (label, category, prompt, parent_id, created_at, updated_at) VALUES (?,?,?,?,?,?)',
+      'INSERT INTO entities (label, category, prompt, parent_id, currency, created_at, updated_at) VALUES (?,?,?,?,?,?,?)',
       cat.label,
       'expense',
       cat.label,
       null,
+      'USD',
       now,
       now
     );
@@ -47,11 +78,12 @@ async function seedDefaultCategories(db: SQLite.SQLiteDatabase) {
     const parentId = parent.id;
     for (const child of cat.children ?? []) {
       await db.runAsync(
-        'INSERT INTO entities (label, category, prompt, parent_id, created_at, updated_at) VALUES (?,?,?,?,?,?)',
+        'INSERT INTO entities (label, category, prompt, parent_id, currency, created_at, updated_at) VALUES (?,?,?,?,?,?,?)',
         child.label,
         'expense',
         child.label,
         parentId,
+        'USD',
         now,
         now
       );

--- a/lib/statements.ts
+++ b/lib/statements.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+import { getDb } from './db';
+
+export const STATEMENT_STATUSES = ['new', 'processed', 'reviewed', 'published'] as const;
+export type StatementStatus = (typeof STATEMENT_STATUSES)[number];
+
+export interface Statement {
+  id: string;
+  bankId: string;
+  uploadDate: number;
+  file: string | null;
+  externalFileId: string | null;
+  status: StatementStatus;
+  processedAt: number | null;
+  reviewedAt: number | null;
+  publishedAt: number | null;
+  archivedAt: number | null;
+}
+
+export const statementSchema = z.object({
+  bankId: z.string(),
+  uploadDate: z.number().int(),
+  file: z.string().nullable().optional(),
+  externalFileId: z.string().nullable().optional(),
+  status: z.enum(STATEMENT_STATUSES).default('new'),
+});
+
+export type StatementInput = z.infer<typeof statementSchema>;
+
+function mapRow(row: any): Statement {
+  return {
+    id: String(row.id),
+    bankId: String(row.bank_id),
+    uploadDate: row.upload_date,
+    file: row.file ?? null,
+    externalFileId: row.external_file_id ?? null,
+    status: row.status as StatementStatus,
+    processedAt: row.processed_at ?? null,
+    reviewedAt: row.reviewed_at ?? null,
+    publishedAt: row.published_at ?? null,
+    archivedAt: row.archived_at ?? null,
+  };
+}
+
+export interface StatementMeta extends Statement {
+  bankLabel: string;
+  transactionCount: number;
+}
+
+export async function createStatement(input: StatementInput): Promise<Statement> {
+  const parsed = statementSchema.parse(input);
+  const db = await getDb();
+  await db.runAsync(
+    'INSERT INTO statements (bank_id, upload_date, file, external_file_id, status) VALUES (?,?,?,?,?)',
+    parsed.bankId,
+    parsed.uploadDate,
+    parsed.file ?? null,
+    parsed.externalFileId ?? null,
+    parsed.status
+  );
+  const row = await db.getFirstAsync<any>(
+    'SELECT * FROM statements WHERE rowid = last_insert_rowid()'
+  );
+  return mapRow(row);
+}
+
+export async function listStatementsWithMeta(): Promise<StatementMeta[]> {
+  const db = await getDb();
+  const rows = await db.getAllAsync<any>(
+    'SELECT * FROM statements ORDER BY upload_date DESC'
+  );
+  const result: StatementMeta[] = [];
+  for (const row of rows) {
+    const stmt = mapRow(row);
+    const countRow = await db.getFirstAsync<{ count: number }>(
+      'SELECT COUNT(*) as count FROM transactions WHERE statement_id=?',
+      stmt.id
+    );
+    const bankRow = await db.getFirstAsync<{ label: string }>(
+      'SELECT label FROM entities WHERE id=?',
+      stmt.bankId
+    );
+    result.push({
+      ...stmt,
+      transactionCount: countRow?.count ?? 0,
+      bankLabel: bankRow?.label ?? '',
+    });
+  }
+  return result;
+}
+
+export async function getStatement(id: string): Promise<Statement | null> {
+  const db = await getDb();
+  const row = await db.getFirstAsync<any>(
+    'SELECT * FROM statements WHERE id=?',
+    id
+  );
+  if (!row) return null;
+  return mapRow(row);
+}

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -1,0 +1,91 @@
+import { z } from 'zod';
+import { getDb } from './db';
+import { Currency, SUPPORTED_CURRENCIES } from './currencies';
+
+export interface Transaction {
+  id: string;
+  statementId: string;
+  recipientId: string | null;
+  senderId: string | null;
+  createdAt: number;
+  processedAt: number | null;
+  archivedAt: number | null;
+  location: string | null;
+  amount: number;
+  currency: Currency;
+  reviewedAt: number | null;
+  shared: boolean;
+  sharedAmount: number | null;
+}
+
+export const transactionSchema = z.object({
+  statementId: z.string(),
+  recipientId: z.string().nullable().optional(),
+  senderId: z.string().nullable().optional(),
+  createdAt: z.number().int(),
+  processedAt: z.number().int().nullable().optional(),
+  archivedAt: z.number().int().nullable().optional(),
+  location: z.string().nullable().optional(),
+  amount: z.number().int().nonnegative(),
+  currency: z.enum(SUPPORTED_CURRENCIES),
+  reviewedAt: z.number().int().nullable().optional(),
+  shared: z.boolean().default(false),
+  sharedAmount: z.number().nullable().optional(),
+});
+
+export type TransactionInput = z.infer<typeof transactionSchema>;
+
+function mapRow(row: any): Transaction {
+  return {
+    id: String(row.id),
+    statementId: String(row.statement_id),
+    recipientId: row.recipient_id ? String(row.recipient_id) : null,
+    senderId: row.sender_id ? String(row.sender_id) : null,
+    createdAt: row.created_at,
+    processedAt: row.processed_at ?? null,
+    archivedAt: row.archived_at ?? null,
+    location: row.location ?? null,
+    amount: row.amount,
+    currency: row.currency as Currency,
+    reviewedAt: row.reviewed_at ?? null,
+    shared: !!row.shared,
+    sharedAmount: row.shared_amount ?? null,
+  };
+}
+
+export async function createTransaction(
+  input: TransactionInput
+): Promise<Transaction> {
+  const parsed = transactionSchema.parse(input);
+  const db = await getDb();
+  await db.runAsync(
+    'INSERT INTO transactions (statement_id, recipient_id, sender_id, created_at, processed_at, archived_at, location, amount, currency, reviewed_at, shared, shared_amount) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)',
+    parsed.statementId,
+    parsed.recipientId ?? null,
+    parsed.senderId ?? null,
+    parsed.createdAt,
+    parsed.processedAt ?? null,
+    parsed.archivedAt ?? null,
+    parsed.location ?? null,
+    parsed.amount,
+    parsed.currency,
+    parsed.reviewedAt ?? null,
+    parsed.shared ? 1 : 0,
+    parsed.sharedAmount ?? null
+  );
+  const row = await db.getFirstAsync<any>(
+    'SELECT * FROM transactions WHERE rowid = last_insert_rowid()'
+  );
+  return mapRow(row);
+}
+
+export async function listTransactions(
+  statementId: string
+): Promise<Transaction[]> {
+  const db = await getDb();
+  const rows = await db.getAllAsync<any>(
+    'SELECT * FROM transactions WHERE statement_id=? ORDER BY created_at DESC',
+    statementId
+  );
+  return rows.map(mapRow);
+}

--- a/test-utils/sqliteMock.ts
+++ b/test-utils/sqliteMock.ts
@@ -1,0 +1,129 @@
+const tables = {
+  entities: [] as any[],
+  statements: [] as any[],
+  transactions: [] as any[],
+};
+
+let counters = { entities: 1, statements: 1, transactions: 1 };
+
+function reset() {
+  tables.entities.length = 0;
+  tables.statements.length = 0;
+  tables.transactions.length = 0;
+  counters = { entities: 1, statements: 1, transactions: 1 };
+}
+
+export const sqliteMock = {
+  __reset: reset,
+  openDatabaseAsync: async () => ({
+    execAsync: async () => {},
+    getAllAsync: async (sql: string, param?: any) => {
+      if (sql.startsWith('SELECT * FROM entities')) {
+        return tables.entities.filter((r) => r.category === param);
+      }
+      if (sql.startsWith('SELECT * FROM statements')) {
+        return [...tables.statements].sort((a, b) => b.upload_date - a.upload_date);
+      }
+      if (sql.startsWith('SELECT * FROM transactions WHERE statement_id=?')) {
+        return tables.transactions
+          .filter((t) => t.statement_id === param)
+          .sort((a, b) => b.created_at - a.created_at);
+      }
+      return [];
+    },
+    getFirstAsync: async (sql: string, param?: any) => {
+      if (sql.startsWith('SELECT COUNT(*) as count FROM entities')) {
+        return {
+          count: tables.entities.filter((r) => r.category === param).length,
+        };
+      }
+      if (sql.startsWith('SELECT COUNT(*) as count FROM transactions')) {
+        return {
+          count: tables.transactions.filter((t) => t.statement_id === param).length,
+        };
+      }
+      if (sql.includes('rowid = last_insert_rowid()')) {
+        const table = sql.includes('FROM entities')
+          ? tables.entities
+          : sql.includes('FROM statements')
+          ? tables.statements
+          : tables.transactions;
+        return table[table.length - 1] ?? null;
+      }
+      if (sql.startsWith('SELECT * FROM entities WHERE id=?')) {
+        return tables.entities.find((r) => r.id === param) ?? null;
+      }
+      if (sql.startsWith('SELECT label FROM entities WHERE id=?')) {
+        const row = tables.entities.find((r) => r.id === param);
+        return row ? { label: row.label } : null;
+      }
+      if (sql.startsWith('SELECT * FROM statements WHERE id=?')) {
+        return tables.statements.find((r) => r.id === param) ?? null;
+      }
+      return null;
+    },
+    runAsync: async (sql: string, ...params: any[]) => {
+      if (sql.startsWith('INSERT INTO entities')) {
+        const [label, category, prompt, parent_id, currency, created_at, updated_at] = params;
+        tables.entities.push({
+          id: String(counters.entities++),
+          label,
+          category,
+          prompt,
+          parent_id,
+          currency,
+          created_at,
+          updated_at,
+        });
+      } else if (sql.startsWith('UPDATE entities')) {
+        const [label, category, prompt, parent_id, currency, updated_at, id] = params;
+        const row = tables.entities.find((r) => r.id === id);
+        if (row) {
+          row.label = label;
+          row.category = category;
+          row.prompt = prompt;
+          row.parent_id = parent_id;
+          row.currency = currency;
+          row.updated_at = updated_at;
+        }
+      } else if (sql.startsWith('DELETE FROM entities')) {
+        const [id] = params;
+        const idx = tables.entities.findIndex((r) => r.id === id);
+        if (idx !== -1) tables.entities.splice(idx, 1);
+      } else if (sql.startsWith('INSERT INTO statements')) {
+        const [bank_id, upload_date, file, external_file_id, status] = params;
+        tables.statements.push({
+          id: String(counters.statements++),
+          bank_id,
+          upload_date,
+          file,
+          external_file_id,
+          status,
+          processed_at: null,
+          reviewed_at: null,
+          published_at: null,
+          archived_at: null,
+        });
+      } else if (sql.startsWith('INSERT INTO transactions')) {
+        const [statement_id, recipient_id, sender_id, created_at, processed_at, archived_at, location, amount, currency, reviewed_at, shared, shared_amount] = params;
+        tables.transactions.push({
+          id: String(counters.transactions++),
+          statement_id,
+          recipient_id,
+          sender_id,
+          created_at,
+          processed_at,
+          archived_at,
+          location,
+          amount,
+          currency,
+          reviewed_at,
+          shared,
+          shared_amount,
+        });
+      }
+    },
+  }),
+};
+
+export default sqliteMock;


### PR DESCRIPTION
## Summary
- add currency handling for entities and bank forms
- introduce statements and transactions tables and APIs
- show statements overview on home screen

## Testing
- `npm ci`
- `npx jest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b40f79563c832880168acda3d27849