### PR TITLE
feat: add statement upload and transactions view

### DIFF
--- a/__tests__/statements.test.ts
+++ b/__tests__/statements.test.ts
@@ -1,12 +1,18 @@
 jest.mock('expo-sqlite', () => require('../test-utils/sqliteMock').sqliteMock);
 
 import { initDb } from '../lib/db';
-import { createBankAccount } from '../lib/entities';
 import {
+  createBankAccount,
+  createExpenseCategory,
+  deleteExpenseCategory,
+  listExpenseCategories,
+} from '../lib/entities';
+import {
+  createDummyStatementWithTransactions,
   createStatement,
   listStatementsWithMeta,
 } from '../lib/statements';
-import { createTransaction } from '../lib/transactions';
+import { createTransaction, listTransactions } from '../lib/transactions';
 const sqlite = require('expo-sqlite');
 
 beforeEach(async () => {
@@ -60,4 +66,47 @@ test('reject negative transaction amount', async () => {
       shared: false,
     })
   ).rejects.toThrow();
+});
+
+test('dummy upload creates statement with transactions', async () => {
+  const bank = await createBankAccount({
+    label: 'Bank',
+    prompt: 'p',
+    currency: 'USD',
+  });
+  await createExpenseCategory({ label: 'E1', prompt: 'p', parentId: null });
+  await createExpenseCategory({ label: 'E2', prompt: 'p', parentId: null });
+  const stmt = await createDummyStatementWithTransactions(bank.id, 'f.pdf');
+  const txns = await listTransactions(stmt.id);
+  expect(txns).toHaveLength(10);
+  for (const t of txns) {
+    expect(t.senderId).toBe(bank.id);
+  }
+});
+
+test('dummy upload rejects when no expense categories', async () => {
+  const bank = await createBankAccount({
+    label: 'Bank',
+    prompt: 'p',
+    currency: 'USD',
+  });
+  const cats = await listExpenseCategories();
+  for (const c of cats) {
+    await deleteExpenseCategory(c.id);
+  }
+  await expect(
+    createDummyStatementWithTransactions(bank.id, 's.pdf')
+  ).rejects.toThrow('No expense categories');
+});
+
+test('dummy upload rejects non pdf', async () => {
+  const bank = await createBankAccount({
+    label: 'Bank',
+    prompt: 'p',
+    currency: 'USD',
+  });
+  await createExpenseCategory({ label: 'E', prompt: 'p', parentId: null });
+  await expect(
+    createDummyStatementWithTransactions(bank.id, 'file.txt')
+  ).rejects.toThrow('Only PDF');
 });

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { FlatList, Text, View } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+import { getEntity } from '../../lib/entities';
+import { listTransactions, Transaction } from '../../lib/transactions';
+
+interface TxnRow extends Transaction {
+  senderLabel: string;
+  recipientLabel: string;
+}
+
+export default function StatementTransactions() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const [transactions, setTransactions] = useState<TxnRow[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      if (!id) return;
+      const list = await listTransactions(id);
+      const enriched: TxnRow[] = [];
+      for (const t of list) {
+        const recipient = t.recipientId
+          ? await getEntity(t.recipientId)
+          : null;
+        const sender = t.senderId ? await getEntity(t.senderId) : null;
+        enriched.push({
+          ...t,
+          recipientLabel: recipient?.label ?? '',
+          senderLabel: sender?.label ?? '',
+        });
+      }
+      setTransactions(enriched);
+    })();
+  }, [id]);
+
+  const Header = () => (
+    <View
+      style={{
+        flexDirection: 'row',
+        paddingVertical: 8,
+        borderBottomWidth: 1,
+      }}
+    >
+      <Text style={{ flex: 1, fontWeight: 'bold' }}>Recipient</Text>
+      <Text style={{ flex: 1, fontWeight: 'bold' }}>Sender</Text>
+      <Text style={{ width: 80, textAlign: 'right', fontWeight: 'bold' }}>
+        Amount
+      </Text>
+      <Text style={{ width: 60, textAlign: 'center', fontWeight: 'bold' }}>
+        Shared
+      </Text>
+      <Text style={{ width: 80, textAlign: 'right', fontWeight: 'bold' }}>
+        Shared Amt
+      </Text>
+    </View>
+  );
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={transactions}
+        keyExtractor={(t) => t.id}
+        ListHeaderComponent={<Header />}
+        ListEmptyComponent={<Text>No transactions</Text>}
+        renderItem={({ item }) => (
+          <View
+            style={{
+              flexDirection: 'row',
+              paddingVertical: 8,
+              borderBottomWidth: 1,
+            }}
+          >
+            <Text style={{ flex: 1 }}>{item.recipientLabel}</Text>
+            <Text style={{ flex: 1 }}>{item.senderLabel}</Text>
+            <Text style={{ width: 80, textAlign: 'right' }}>{item.amount}</Text>
+            <Text style={{ width: 60, textAlign: 'center' }}>
+              {item.shared ? 'Yes' : 'No'}
+            </Text>
+            <Text style={{ width: 80, textAlign: 'right' }}>
+              {item.sharedAmount ?? '-'}
+            </Text>
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "expo": "~53.0.20",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.7",
+        "expo-document-picker": "^13.1.6",
         "expo-font": "~13.3.2",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.4.0",
@@ -6286,6 +6287,15 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-13.1.6.tgz",
+      "integrity": "sha512-8FTQPDOkyCvFN/i4xyqzH7ELW4AsB6B3XBZQjn1FEdqpozo6rpNJRr7sWFU/93WrLgA9FJEKpKbyr6XxczK6BA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "expo": "~53.0.20",
     "expo-blur": "~14.1.5",
     "expo-constants": "~17.1.7",
+    "expo-document-picker": "^13.1.6",
     "expo-font": "~13.3.2",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.4.0",


### PR DESCRIPTION
## Summary
- add statement upload modal that creates dummy transactions
- show transactions for a statement with sender/recipient and share info
- test dummy upload scenarios and edge cases

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx jest`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b42f0093a483288175ef5cc703a92d