### PR TITLE
Refresh bank list on statement upload modal

### DIFF
--- a/__tests__/modal-banks.test.ts
+++ b/__tests__/modal-banks.test.ts
@@ -1,0 +1,17 @@
+import { loadBanksForModal } from '../lib/banks';
+import { listBankAccounts } from '../lib/entities';
+
+jest.mock('../lib/entities', () => ({
+  listBankAccounts: jest.fn(),
+}));
+
+test('loadBanksForModal fetches banks and shows modal', async () => {
+  const mockBanks = [{ id: '1', label: 'B', category: 'bank', prompt: '', currency: 'USD', parentId: null }];
+  (listBankAccounts as jest.Mock).mockResolvedValue(mockBanks);
+  const setBanks = jest.fn();
+  const setModalVisible = jest.fn();
+  await loadBanksForModal(setBanks, setModalVisible);
+  expect(listBankAccounts).toHaveBeenCalledTimes(1);
+  expect(setBanks).toHaveBeenCalledWith(mockBanks);
+  expect(setModalVisible).toHaveBeenCalledWith(true);
+});

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -9,12 +9,13 @@ import {
   Text,
   View,
 } from 'react-native';
-import { Entity, listBankAccounts } from '../lib/entities';
+import { Entity } from '../lib/entities';
 import {
   createDummyStatementWithTransactions,
   listStatementsWithMeta,
   StatementMeta,
 } from '../lib/statements';
+import { loadBanksForModal } from '../lib/banks';
 
 function StatusRow({ item }: { item: StatementMeta }) {
   const statuses = [
@@ -46,8 +47,6 @@ export default function Index() {
     (async () => {
       const list = await listStatementsWithMeta();
       setStatements(list);
-      const b = await listBankAccounts();
-      setBanks(b);
     })();
   }, []);
 
@@ -74,6 +73,10 @@ export default function Index() {
     setFile(null);
   };
 
+  const openUploadModal = async () => {
+    await loadBanksForModal(setBanks, setModalVisible);
+  };
+
   return (
     <View style={{ flex: 1, padding: 16, paddingTop: 48 }}>
       <Button title="Banks" onPress={() => router.push("/bank-accounts")} />
@@ -81,7 +84,7 @@ export default function Index() {
         
         
       
-      <Button title="Upload Statement" onPress={() => setModalVisible(true)} />
+      <Button title="Upload Statement" onPress={openUploadModal} />
       <FlatList
         data={statements}
         keyExtractor={(s) => s.id}
@@ -107,7 +110,7 @@ export default function Index() {
         )}
       />
       <Modal visible={modalVisible} animationType="slide">
-        <View style={{ flex: 1, padding: 16, paddingTop: 100 }}>
+        <View style={{ flex: 1, padding: 16, paddingTop: 120 }}>
           <Text style={{ fontSize: 18, marginBottom: 8 }}>Select Bank</Text>
           {banks.map((b) => (
             <Pressable

--- a/lib/banks.ts
+++ b/lib/banks.ts
@@ -1,0 +1,10 @@
+import { Entity, listBankAccounts } from './entities';
+
+export async function loadBanksForModal(
+  setBanks: (banks: Entity[]) => void,
+  setModalVisible: (visible: boolean) => void
+) {
+  const b = await listBankAccounts();
+  setBanks(b);
+  setModalVisible(true);
+}


### PR DESCRIPTION
## Summary
- Load banks when opening the statement upload modal so the list is always current
- Increase top padding inside the upload modal
- Add tests for modal bank loading helper

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b4802689a48328aa234fb05a2139a7