### PR TITLE
fix: clean babel config for eas update

### DIFF
--- a/.github/workflows/production-update.yml
+++ b/.github/workflows/production-update.yml
@@ -15,4 +15,5 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           APP_ENV: staging
-        run: npx eas update --channel staging --non-interactive --message "CI ${GITHUB_SHA}"
+        # Use the locally installed eas-cli to avoid version drift
+        run: npx --no-install eas update --channel staging --non-interactive --message "CI ${GITHUB_SHA}"

--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ Join our community of developers creating universal apps.
 
 - [Expo on GitHub](https://github.com/expo/expo): View our open source platform and contribute.
 - [Discord community](https://chat.expo.dev): Chat with Expo users and ask questions.
+
+## Continuous Integration & Babel
+
+The GitHub workflow installs dependencies with `npm ci` and runs `npx --no-install eas update`. The `eas-cli` version is pinned in `devDependencies`, so both local development and CI use the same release.
+
+If bundling fails with a Babel error:
+
+- Confirm `babel.config.js` only includes `expo-router/babel` and `react-native-reanimated/plugin` (the latter must be last).
+- Clear Metro's cache with `npx expo start -c`.
+- Ensure you're using the pinned `eas-cli` version by reinstalling dependencies with `npm ci`.

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,11 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['nativewind/babel'],
+    plugins: [
+      // Enable file-based routing for expo-router
+      'expo-router/babel',
+      // Must be last for react-native-reanimated
+      'react-native-reanimated/plugin',
+    ],
   };
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@babel/core": "^7.25.2",
     "@types/jest": "^29.5.14",
     "@types/react": "~19.0.10",
-    "eas-cli": "^16.18.0",
+    "eas-cli": "16.18.0",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- simplify Babel config to expo-router and reanimated plugins
- pin eas-cli version and run local CLI in CI
- document CI/Babel setup in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b48ff676988328adb406daf3e987e8