### PR TITLE
Use React Native Paper DataTable for statement lists

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,8 +1,8 @@
 import * as DocumentPicker from 'expo-document-picker';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { FlatList, Modal, Pressable, View } from 'react-native';
-import { Button, Text } from 'react-native-paper';
+import { Modal, Pressable, ScrollView, View } from 'react-native';
+import { Button, DataTable, Text } from 'react-native-paper';
 import { Entity } from '../lib/entities';
 import {
   createDummyStatementWithTransactions,
@@ -80,26 +80,35 @@ export default function Index() {
         Expense categories
       </Button>
       <Button onPress={openUploadModal}>Upload Statement</Button>
-      <FlatList
-        data={statements}
-        keyExtractor={(s) => s.id}
-        ListEmptyComponent={<Text>No statements</Text>}
-        renderItem={({ item }) => (
-          <Pressable
-            onPress={() => router.push(`/statements/${item.id}`)}
-            style={{ flexDirection: 'row', paddingVertical: 8, borderBottomWidth: 1 }}
-          >
-            <Text style={{ flex: 1 }}>{item.bankLabel}</Text>
-            <Text style={{ flex: 1 }}>
-              {new Date(item.uploadDate).toLocaleDateString()}
-            </Text>
-            <Text style={{ width: 40, textAlign: 'center' }}>
-              {item.transactionCount}
-            </Text>
-            <StatusRow item={item} />
-          </Pressable>
-        )}
-      />
+      {statements.length === 0 ? (
+        <Text>No statements</Text>
+      ) : (
+        <ScrollView>
+          <DataTable>
+            <DataTable.Header>
+              <DataTable.Title>Bank</DataTable.Title>
+              <DataTable.Title>Upload Date</DataTable.Title>
+              <DataTable.Title numeric>Txns</DataTable.Title>
+              <DataTable.Title>Progress</DataTable.Title>
+            </DataTable.Header>
+            {statements.map((item) => (
+              <DataTable.Row
+                key={item.id}
+                onPress={() => router.push(`/statements/${item.id}`)}
+              >
+                <DataTable.Cell>{item.bankLabel}</DataTable.Cell>
+                <DataTable.Cell>
+                  {new Date(item.uploadDate).toLocaleDateString()}
+                </DataTable.Cell>
+                <DataTable.Cell numeric>{item.transactionCount}</DataTable.Cell>
+                <DataTable.Cell style={{ width: 80 }}>
+                  <StatusRow item={item} />
+                </DataTable.Cell>
+              </DataTable.Row>
+            ))}
+          </DataTable>
+        </ScrollView>
+      )}
       <Modal visible={modalVisible} animationType="slide">
         <View style={{ flex: 1, padding: 16, paddingTop: 128 }}>
           <Text style={{ fontSize: 18, marginBottom: 8 }}>Select Bank</Text>

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
-import { FlatList, View } from 'react-native';
-import { Text } from 'react-native-paper';
+import { ScrollView, View } from 'react-native';
+import { DataTable, Text } from 'react-native-paper';
 import { useLocalSearchParams } from 'expo-router';
 import { getEntity } from '../../lib/entities';
 import { listTransactions, Transaction } from '../../lib/transactions';
@@ -34,47 +34,38 @@ export default function StatementTransactions() {
     })();
   }, [id]);
 
-  const Header = () => (
-    <View
-      style={{ flexDirection: 'row', paddingVertical: 8, borderBottomWidth: 1 }}
-    >
-      <Text style={{ flex: 1, fontWeight: 'bold' }}>Recipient</Text>
-      <Text style={{ flex: 1, fontWeight: 'bold' }}>Sender</Text>
-      <Text style={{ width: 80, textAlign: 'right', fontWeight: 'bold' }}>
-        Amount
-      </Text>
-      <Text style={{ width: 64, textAlign: 'center', fontWeight: 'bold' }}>
-        Shared
-      </Text>
-      <Text style={{ width: 80, textAlign: 'right', fontWeight: 'bold' }}>
-        Shared Amt
-      </Text>
-    </View>
-  );
-
   return (
     <View style={{ flex: 1, padding: 16 }}>
-      <FlatList
-        data={transactions}
-        keyExtractor={(t) => t.id}
-        ListHeaderComponent={<Header />}
-        ListEmptyComponent={<Text>No transactions</Text>}
-        renderItem={({ item }) => (
-          <View
-            style={{ flexDirection: 'row', paddingVertical: 8, borderBottomWidth: 1 }}
-          >
-            <Text style={{ flex: 1 }}>{item.recipientLabel}</Text>
-            <Text style={{ flex: 1 }}>{item.senderLabel}</Text>
-            <Text style={{ width: 80, textAlign: 'right' }}>{item.amount}</Text>
-            <Text style={{ width: 64, textAlign: 'center' }}>
-              {item.shared ? 'Yes' : 'No'}
-            </Text>
-            <Text style={{ width: 80, textAlign: 'right' }}>
-              {item.sharedAmount ?? '-'}
-            </Text>
-          </View>
-        )}
-      />
+      {transactions.length === 0 ? (
+        <Text>No transactions</Text>
+      ) : (
+        <ScrollView>
+          <DataTable>
+            <DataTable.Header>
+              <DataTable.Title>Recipient</DataTable.Title>
+              <DataTable.Title>Sender</DataTable.Title>
+              <DataTable.Title numeric>Amount</DataTable.Title>
+              <DataTable.Title style={{ justifyContent: 'center', width: 64 }}>
+                Shared
+              </DataTable.Title>
+              <DataTable.Title numeric>Shared Amt</DataTable.Title>
+            </DataTable.Header>
+            {transactions.map((item) => (
+              <DataTable.Row key={item.id}>
+                <DataTable.Cell>{item.recipientLabel}</DataTable.Cell>
+                <DataTable.Cell>{item.senderLabel}</DataTable.Cell>
+                <DataTable.Cell numeric>{item.amount}</DataTable.Cell>
+                <DataTable.Cell style={{ justifyContent: 'center', width: 64 }}>
+                  {item.shared ? 'Yes' : 'No'}
+                </DataTable.Cell>
+                <DataTable.Cell numeric>
+                  {item.sharedAmount ?? '-'}
+                </DataTable.Cell>
+              </DataTable.Row>
+            ))}
+          </DataTable>
+        </ScrollView>
+      )}
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- replace FlatList with Paper DataTable on home screen
- use Paper DataTable for statement transaction list

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_68b496c1a68c8328ad79178d5ac9bc60