### PR TITLE
fix: include wasm assets for expo-sqlite

### DIFF
--- a/__tests__/metro.config.test.ts
+++ b/__tests__/metro.config.test.ts
@@ -1,0 +1,8 @@
+import metroConfig = require('../metro.config');
+
+describe('metro.config', () => {
+  test('includes wasm in assetExts', () => {
+    const assetExts = metroConfig?.resolver?.assetExts ?? [];
+    expect(assetExts).toContain('wasm');
+  });
+});

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,10 @@
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+// Treat WebAssembly files as assets so Metro can bundle them
+if (!config.resolver.assetExts.includes('wasm')) {
+  config.resolver.assetExts.push('wasm');
+}
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- ensure Metro bundles `.wasm` files
- add test covering Metro config

## Testing
- `npm test` *(expo-doctor failed: Check Expo config, Check for legacy global CLI installed locally, Check that native modules use compatible support package versions for installed Expo SDK, Validate packages against React Native Directory package metadata)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a945c480832880ac9a6d9782ad9f