### PR TITLE
fix: lazy init sqlite

### DIFF
--- a/__tests__/db.test.ts
+++ b/__tests__/db.test.ts
@@ -1,0 +1,16 @@
+jest.mock('expo-sqlite', () => require('../test-utils/sqliteMock').sqliteMock);
+
+import { getDb } from '../lib/db';
+const sqlite = require('expo-sqlite');
+
+it('opens database lazily and only once', async () => {
+  const openSpy = jest.spyOn(sqlite, 'openDatabaseAsync');
+  expect(openSpy).not.toHaveBeenCalled();
+
+  const first = await getDb();
+  expect(openSpy).toHaveBeenCalledTimes(1);
+
+  const second = await getDb();
+  expect(openSpy).toHaveBeenCalledTimes(1);
+  expect(second).toBe(first);
+});

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,14 +1,21 @@
 import * as SQLite from 'expo-sqlite';
 import { DEFAULT_EXPENSE_CATEGORIES } from './defaultCategories';
 
-const dbPromise = SQLite.openDatabaseAsync('app_v2.db');
+let dbPromise: Promise<SQLite.SQLiteDatabase> | null = null;
+
+function ensureDb(): Promise<SQLite.SQLiteDatabase> {
+  if (!dbPromise) {
+    dbPromise = SQLite.openDatabaseAsync('app_v2.db');
+  }
+  return dbPromise!;
+}
 
 export async function getDb() {
-  return dbPromise;
+  return ensureDb();
 }
 
 export async function initDb() {
-  const db = await dbPromise;
+  const db = await ensureDb();
   await db.execAsync(
     `CREATE TABLE IF NOT EXISTS entities(
       id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
## Summary
- initialize SQLite database lazily to avoid export crashes
- add test ensuring database opens only when needed

## Testing
- `npm test` (fails: Check Expo config (app.json/ app.config.js) schema; Check that native modules use compatible support package versions for installed Expo SDK)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4ab5dbae48328829ac2f6fa349d5a