### PR TITLE
feat: enhance statement view

### DIFF
--- a/__tests__/transactions.test.ts
+++ b/__tests__/transactions.test.ts
@@ -1,0 +1,36 @@
+jest.mock('expo-sqlite', () => require('../test-utils/sqliteMock').sqliteMock);
+
+import { createTransaction, updateTransaction, listTransactions } from '../lib/transactions';
+import sqliteMock from '../test-utils/sqliteMock';
+
+describe('transactions', () => {
+  beforeEach(() => {
+    // reset mock db
+    // @ts-ignore
+    sqliteMock.__reset();
+  });
+
+  it('updates shared fields and description', async () => {
+    const txn = await createTransaction({
+      statementId: '1',
+      recipientId: null,
+      senderId: null,
+      createdAt: Date.now(),
+      amount: 100,
+      currency: 'USD',
+      shared: false,
+      description: null,
+    });
+    await updateTransaction(txn.id, {
+      shared: true,
+      sharedAmount: 40,
+      description: 'Dinner',
+    });
+    const list = await listTransactions('1');
+    expect(list[0]).toMatchObject({
+      shared: true,
+      sharedAmount: 40,
+      description: 'Dinner',
+    });
+  });
+});

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -1,9 +1,26 @@
 import { useEffect, useState } from 'react';
-import { ScrollView, View } from 'react-native';
-import { DataTable, Text } from 'react-native-paper';
+import { Alert, ScrollView, View } from 'react-native';
+import {
+  DataTable,
+  Text,
+  Switch,
+  Portal,
+  Modal,
+  List,
+} from 'react-native-paper';
 import { useLocalSearchParams } from 'expo-router';
-import { getEntity } from '../../lib/entities';
-import { listTransactions, Transaction } from '../../lib/transactions';
+import {
+  getEntity,
+  listEntities,
+  Entity,
+  EntityCategory,
+} from '../../lib/entities';
+import {
+  listTransactions,
+  Transaction,
+  updateTransaction,
+} from '../../lib/transactions';
+import { getStatement } from '../../lib/statements';
 
 interface TxnRow extends Transaction {
   senderLabel: string;
@@ -13,11 +30,26 @@ interface TxnRow extends Transaction {
 export default function StatementTransactions() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const [transactions, setTransactions] = useState<TxnRow[]>([]);
+  const [entities, setEntities] = useState<Entity[]>([]);
+  const [picker, setPicker] = useState<{ txnId: string; field: 'sender' | 'recipient' } | null>(null);
+  const [meta, setMeta] = useState<{
+    uploadDate: number;
+    earliest: number;
+    latest: number;
+    bank: string;
+    currency: string;
+    count: number;
+  } | null>(null);
+  const [sortBy, setSortBy] = useState<'date' | 'amount'>('date');
+  const [ascending, setAscending] = useState(false);
 
   useEffect(() => {
     (async () => {
       if (!id) return;
-      const list = await listTransactions(id);
+      const [stmt, list] = await Promise.all([
+        getStatement(id),
+        listTransactions(id),
+      ]);
       const enriched: TxnRow[] = [];
       for (const t of list) {
         const recipient = t.recipientId
@@ -31,41 +63,271 @@ export default function StatementTransactions() {
         });
       }
       setTransactions(enriched);
+      if (stmt) {
+        const bank = await getEntity(stmt.bankId);
+        const dates = list.map((t) => t.createdAt);
+        setMeta({
+          uploadDate: stmt.uploadDate,
+          earliest: Math.min(...dates),
+          latest: Math.max(...dates),
+          bank: bank?.label ?? '',
+          currency: bank?.currency ?? '',
+          count: list.length,
+        });
+      }
     })();
   }, [id]);
 
+  useEffect(() => {
+    (async () => {
+      const cats: EntityCategory[] = ['bank', 'expense', 'income', 'savings'];
+      const lists = await Promise.all(cats.map((c) => listEntities(c)));
+      setEntities(lists.flat());
+    })();
+  }, []);
+
+  const formatDate = (ts: number) => new Date(ts).toLocaleDateString();
+
+  const sorted = [...transactions].sort((a, b) => {
+    const aVal =
+      sortBy === 'date' ? a.createdAt : a.sharedAmount ?? a.amount;
+    const bVal =
+      sortBy === 'date' ? b.createdAt : b.sharedAmount ?? b.amount;
+    return ascending ? aVal - bVal : bVal - aVal;
+  });
+
+  const toggleSort = (col: 'date' | 'amount') => {
+    if (sortBy === col) {
+      setAscending(!ascending);
+    } else {
+      setSortBy(col);
+      setAscending(false);
+    }
+  };
+
+  const handleToggleShared = (txn: TxnRow, value: boolean) => {
+    if (value) {
+      Alert.prompt(
+        'Shared Amount',
+        'Enter shared amount',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'OK',
+            onPress: async (text) => {
+              const amt = Number(text);
+              if (isNaN(amt)) return;
+              await updateTransaction(txn.id, {
+                shared: true,
+                sharedAmount: amt,
+              });
+              setTransactions((prev) =>
+                prev.map((t) =>
+                  t.id === txn.id
+                    ? { ...t, shared: true, sharedAmount: amt }
+                    : t
+                )
+              );
+            },
+          },
+        ],
+        'plain-text',
+        txn.sharedAmount ? String(txn.sharedAmount) : ''
+      );
+    } else {
+      (async () => {
+        await updateTransaction(txn.id, { shared: false, sharedAmount: null });
+        setTransactions((prev) =>
+          prev.map((t) =>
+            t.id === txn.id ? { ...t, shared: false, sharedAmount: null } : t
+          )
+        );
+      })();
+    }
+  };
+
+  const editSharedAmount = (txn: TxnRow) => {
+    Alert.prompt(
+      'Shared Amount',
+      'Enter shared amount',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'OK',
+          onPress: async (text) => {
+            const amt = Number(text);
+            if (isNaN(amt)) return;
+            await updateTransaction(txn.id, { sharedAmount: amt });
+            setTransactions((prev) =>
+              prev.map((t) =>
+                t.id === txn.id ? { ...t, sharedAmount: amt } : t
+              )
+            );
+          },
+        },
+      ],
+      'plain-text',
+      txn.sharedAmount ? String(txn.sharedAmount) : ''
+    );
+  };
+
+  const editDescription = (txn: TxnRow) => {
+    Alert.prompt(
+      'Description',
+      'Enter description',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'OK',
+          onPress: async (text) => {
+            await updateTransaction(txn.id, { description: text });
+            setTransactions((prev) =>
+              prev.map((t) =>
+                t.id === txn.id ? { ...t, description: text } : t
+              )
+            );
+          },
+        },
+      ],
+      'plain-text',
+      txn.description ?? ''
+    );
+  };
+
+  const openEntityPicker = (txnId: string, field: 'sender' | 'recipient') => {
+    setPicker({ txnId, field });
+  };
+
+  const selectEntity = async (entityId: string) => {
+    if (!picker) return;
+    const field = picker.field === 'sender' ? { senderId: entityId } : { recipientId: entityId };
+    await updateTransaction(picker.txnId, field);
+    const label = entities.find((e) => e.id === entityId)?.label ?? '';
+    setTransactions((prev) =>
+      prev.map((t) =>
+        t.id === picker.txnId
+          ? {
+              ...t,
+              ...(picker.field === 'sender'
+                ? { senderId: entityId, senderLabel: label }
+                : { recipientId: entityId, recipientLabel: label }),
+            }
+          : t
+      )
+    );
+    setPicker(null);
+  };
+
   return (
     <View style={{ flex: 1, padding: 16 }}>
+      {meta && (
+        <View style={{ marginBottom: 16 }}>
+          <Text>Uploaded: {formatDate(meta.uploadDate)}</Text>
+          <Text>
+            Date Range: {formatDate(meta.earliest)} - {formatDate(meta.latest)}
+          </Text>
+          <Text>
+            Bank: {meta.bank} ({meta.currency})
+          </Text>
+          <Text>Transactions: {meta.count}</Text>
+        </View>
+      )}
       {transactions.length === 0 ? (
         <Text>No transactions</Text>
       ) : (
         <ScrollView>
           <DataTable>
             <DataTable.Header>
-              <DataTable.Title>Recipient</DataTable.Title>
+              <DataTable.Title
+                sortDirection={
+                  sortBy === 'date' ? (ascending ? 'ascending' : 'descending') : undefined
+                }
+                onPress={() => toggleSort('date')}
+              >
+                Date
+              </DataTable.Title>
               <DataTable.Title>Sender</DataTable.Title>
-              <DataTable.Title numeric>Amount</DataTable.Title>
+              <DataTable.Title>Recipient</DataTable.Title>
+              <DataTable.Title>Description</DataTable.Title>
+              <DataTable.Title
+                numeric
+                sortDirection={
+                  sortBy === 'amount'
+                    ? ascending
+                      ? 'ascending'
+                      : 'descending'
+                    : undefined
+                }
+                onPress={() => toggleSort('amount')}
+              >
+                Amount
+              </DataTable.Title>
               <DataTable.Title style={{ justifyContent: 'center', width: 64 }}>
                 Shared
               </DataTable.Title>
-              <DataTable.Title numeric>Shared Amt</DataTable.Title>
             </DataTable.Header>
-            {transactions.map((item) => (
+            {sorted.map((item) => (
               <DataTable.Row key={item.id}>
-                <DataTable.Cell>{item.recipientLabel}</DataTable.Cell>
-                <DataTable.Cell>{item.senderLabel}</DataTable.Cell>
-                <DataTable.Cell numeric>{item.amount}</DataTable.Cell>
-                <DataTable.Cell style={{ justifyContent: 'center', width: 64 }}>
-                  {item.shared ? 'Yes' : 'No'}
+                <DataTable.Cell>{formatDate(item.createdAt)}</DataTable.Cell>
+                <DataTable.Cell onPress={() => openEntityPicker(item.id, 'sender')}>
+                  {item.senderLabel}
                 </DataTable.Cell>
-                <DataTable.Cell numeric>
-                  {item.sharedAmount ?? '-'}
+                <DataTable.Cell onPress={() => openEntityPicker(item.id, 'recipient')}>
+                  {item.recipientLabel}
+                </DataTable.Cell>
+                <DataTable.Cell onPress={() => editDescription(item)}>
+                  {item.description ?? '-'}
+                </DataTable.Cell>
+                <DataTable.Cell
+                  numeric
+                  onPress={() => item.shared && editSharedAmount(item)}
+                >
+                  {item.shared
+                    ? `${item.sharedAmount} (${item.amount})`
+                    : item.amount}
+                </DataTable.Cell>
+                <DataTable.Cell style={{ justifyContent: 'center', width: 64 }}>
+                  <Switch
+                    value={item.shared}
+                    onValueChange={(v) => handleToggleShared(item, v)}
+                  />
                 </DataTable.Cell>
               </DataTable.Row>
             ))}
           </DataTable>
         </ScrollView>
       )}
+      <Portal>
+        <Modal visible={!!picker} onDismiss={() => setPicker(null)}>
+          <ScrollView style={{ maxHeight: 400 }}>
+            {(['bank', 'expense', 'income', 'savings'] as EntityCategory[]).map(
+              (cat) => (
+                <List.Section key={cat} title={cat.toUpperCase()}>
+                  {entities
+                    .filter((e) => e.category === cat && !e.parentId)
+                    .map((parent) => (
+                      <View key={parent.id}>
+                        <List.Item
+                          title={parent.label}
+                          onPress={() => selectEntity(parent.id)}
+                        />
+                        {entities
+                          .filter((c) => c.parentId === parent.id)
+                          .map((child) => (
+                            <List.Item
+                              key={child.id}
+                              title={`  ${child.label}`}
+                              onPress={() => selectEntity(child.id)}
+                            />
+                          ))}
+                      </View>
+                    ))}
+                </List.Section>
+              )
+            )}
+          </ScrollView>
+        </Modal>
+      </Portal>
     </View>
   );
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -50,6 +50,7 @@ export async function initDb() {
       processed_at INTEGER,
       archived_at INTEGER,
       location TEXT,
+      description TEXT,
       amount INTEGER NOT NULL,
       currency TEXT NOT NULL,
       reviewed_at INTEGER,

--- a/lib/statements.ts
+++ b/lib/statements.ts
@@ -167,6 +167,7 @@ export async function createDummyStatementWithTransactions(
       currency: bank.currency,
       shared,
       sharedAmount: shared ? Math.floor(amount / 2) : null,
+      description: null,
     });
   }
   return statement;


### PR DESCRIPTION
## Summary
- allow editing transactions directly in statement view
- support shared amounts and descriptions for transactions
- add transaction update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b43ef47c83288bf59e0112ca641d