### PR TITLE
feat: support landscape mode and transaction review

### DIFF
--- a/__tests__/statements.test.ts
+++ b/__tests__/statements.test.ts
@@ -48,6 +48,8 @@ test('statement listing shows transaction count and bank label', async () => {
   const statements = await listStatementsWithMeta();
   expect(statements[0].transactionCount).toBe(2);
   expect(statements[0].bankLabel).toBe('Bank');
+  expect(statements[0].earliest).toBe(1);
+  expect(statements[0].latest).toBe(2);
 });
 
 test('reject negative transaction amount', async () => {

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "true-ledger",
     "slug": "true-ledger",
     "version": "1.0.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "trueledger",
     "userInterfaceStyle": "automatic",

--- a/app/bank-accounts/form.tsx
+++ b/app/bank-accounts/form.tsx
@@ -58,6 +58,7 @@ export default function BankAccountForm({ initial, onSubmit, submitLabel }: Prop
         <Menu
           visible={menuVisible}
           onDismiss={() => setMenuVisible(false)}
+          style={{ maxHeight: 300 }}
           anchor={
             <Button mode="outlined" onPress={() => setMenuVisible(true)} style={{ marginBottom: 12 }}>
               {currency}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -2,7 +2,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons';
 import * as DocumentPicker from 'expo-document-picker';
 import { useRouter } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { Modal, ScrollView, View } from 'react-native';
+import { Modal, ScrollView, View, useWindowDimensions } from 'react-native';
 import { BottomNavigation, Button, DataTable, Dialog, FAB, IconButton, List, Menu, Portal, RadioButton, SegmentedButtons, Text } from 'react-native-paper';
 import { loadBanksForModal } from '../lib/banks';
 import { Entity } from '../lib/entities';
@@ -142,6 +142,15 @@ export default function Index() {
     const [viewArchived, setViewArchived] = useState<'current' | 'archived'>('current');
     const [confirmVisible, setConfirmVisible] = useState(false);
     const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+    const { width, height } = useWindowDimensions();
+    const isLandscape = width > height;
+
+    const formatRange = (start: number | null, end: number | null) => {
+      if (!start || !end) return '-';
+      const from = new Date(start).toLocaleDateString();
+      const to = new Date(end).toLocaleDateString();
+      return from === to ? from : `${from} - ${to}`;
+    };
 
     const sorted = statements.slice().sort((a, b) => b.uploadDate - a.uploadDate);
     const filtered = sorted.filter((s) =>
@@ -164,18 +173,22 @@ export default function Index() {
           <ScrollView>
             <DataTable>
               <DataTable.Header>
-                <DataTable.Title>Created</DataTable.Title>
+                {isLandscape && <DataTable.Title>Created</DataTable.Title>}
                 <DataTable.Title>Bank</DataTable.Title>
-                <DataTable.Title>File</DataTable.Title>
+                <DataTable.Title>Date Range</DataTable.Title>
                 <DataTable.Title numeric>Txns</DataTable.Title>
                 <DataTable.Title>Status</DataTable.Title>
                 <DataTable.Title>Actions</DataTable.Title>
               </DataTable.Header>
               {filtered.map((item) => (
                 <DataTable.Row key={item.id} onPress={() => router.push(`/statements/${item.id}`)}>
-                  <DataTable.Cell>{new Date(item.uploadDate).toLocaleDateString()}</DataTable.Cell>
+                  {isLandscape && (
+                    <DataTable.Cell>
+                      {new Date(item.uploadDate).toLocaleDateString()}
+                    </DataTable.Cell>
+                  )}
                   <DataTable.Cell>{item.bankLabel}</DataTable.Cell>
-                  <DataTable.Cell>{item.file ?? '-'}</DataTable.Cell>
+                  <DataTable.Cell>{formatRange(item.earliest, item.latest)}</DataTable.Cell>
                   <DataTable.Cell numeric>{item.transactionCount}</DataTable.Cell>
                   <DataTable.Cell>
                     {/* compute latest status */}

--- a/lib/currencies.ts
+++ b/lib/currencies.ts
@@ -1,14 +1,24 @@
 export const SUPPORTED_CURRENCIES = [
   'EUR',
-  'CHF',
   'USD',
+  'CHF',
   'BRL',
   'GBP',
   'JPY',
-  'CAD',
   'AUD',
+  'CAD',
   'CNY',
   'SEK',
+  'NZD',
+  'MXN',
+  'INR',
+  'HKD',
+  'SGD',
+  'KRW',
+  'NOK',
+  'TRY',
+  'RUB',
+  'ZAR',
 ] as const;
 
 export type Currency = (typeof SUPPORTED_CURRENCIES)[number];


### PR DESCRIPTION
## Summary
- enable landscape orientation and responsive tables
- allow reviewing transactions via checkbox and auto-update statement status
- expand currency list and improve selection menus

## Testing
- `npm test`
- `npx expo-doctor` *(fails: fetch failed / connection unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c0b1296483289c669ae6fdcb7e65