### PR TITLE
Add OpenAI statement processing and configurable system prompt

### DIFF
--- a/__tests__/openai.test.ts
+++ b/__tests__/openai.test.ts
@@ -1,0 +1,82 @@
+jest.mock('expo-sqlite', () => require('../test-utils/sqliteMock').sqliteMock);
+
+import { initDb } from '../lib/db';
+import { createBankAccount, createExpenseCategory } from '../lib/entities';
+import { createStatement, getStatement } from '../lib/statements';
+import { processStatementFile, DEFAULT_SYSTEM_PROMPT } from '../lib/openai';
+const sqlite = require('expo-sqlite');
+
+describe('openai processing', () => {
+  beforeEach(async () => {
+    sqlite.__reset();
+    await initDb();
+  });
+
+  test('processStatementFile uploads and creates thread', async () => {
+    const bank = await createBankAccount({
+      label: 'Bank',
+      prompt: 'bank prompt',
+      currency: 'USD',
+    });
+    await createExpenseCategory({ label: 'Food', prompt: 'p', parentId: null });
+    const stmt = await createStatement({
+      bankId: bank.id,
+      uploadDate: Date.now(),
+      file: 'f.pdf',
+      status: 'new',
+    });
+    const fakeFetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'file123' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'thread456' }),
+      });
+    // @ts-ignore
+    global.fetch = fakeFetch;
+    await processStatementFile({
+      statementId: stmt.id,
+      bankId: bank.id,
+      file: new Blob(['x']),
+      apiKey: 'sk',
+      systemPrompt: DEFAULT_SYSTEM_PROMPT,
+    });
+    const updated = await getStatement(stmt.id);
+    expect(updated?.externalFileId).toBe('file123');
+    expect(updated?.status).toBe('processed');
+    expect(fakeFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('processStatementFile sets error on failure', async () => {
+    const bank = await createBankAccount({
+      label: 'Bank',
+      prompt: 'p',
+      currency: 'USD',
+    });
+    await createExpenseCategory({ label: 'Food', prompt: 'p', parentId: null });
+    const stmt = await createStatement({
+      bankId: bank.id,
+      uploadDate: Date.now(),
+      file: 'f.pdf',
+      status: 'new',
+    });
+    const fakeFetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
+    // @ts-ignore
+    global.fetch = fakeFetch;
+    await expect(
+      processStatementFile({
+        statementId: stmt.id,
+        bankId: bank.id,
+        file: new Blob(['x']),
+        apiKey: 'sk',
+        systemPrompt: DEFAULT_SYSTEM_PROMPT,
+      })
+    ).rejects.toThrow();
+    const updated = await getStatement(stmt.id);
+    expect(updated?.status).toBe('error');
+  });
+});
+

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -1,0 +1,94 @@
+import { getDb } from './db';
+import { getEntity, listExpenseCategories } from './entities';
+
+export const OPENAI_KEY_STORAGE_KEY = 'openai_api_key';
+export const SYSTEM_PROMPT_STORAGE_KEY = 'system_prompt';
+export const DEFAULT_SYSTEM_PROMPT = `You are a precise financial data parser. Extract all transactions from this bank statement PDF. Format as JSON with the following schema.{
+  "transactions": [
+    {
+      "date": "YYYY-MM-DD",
+      "description": "Transaction description, add all information that helps understand what this transaction was about. Like bank numbers or any other reference.",
+      "amount": number,
+      "category": "expense category which are stated below",
+      "location": "zurich" | "brasil" | "germany"  | "europe",
+      "isShared": true | false,
+    }
+  ]
+}
+`;
+
+async function uploadFile(apiKey: string, file: any): Promise<string> {
+  const form = new FormData();
+  form.append('purpose', 'assistants');
+  form.append('file', file);
+  const res = await fetch('https://api.openai.com/v1/files', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}` },
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error('file upload failed');
+  }
+  const json = await res.json();
+  return json.id as string;
+}
+
+async function createThread(apiKey: string, fileId: string, prompt: string) {
+  const res = await fetch('https://api.openai.com/v1/threads', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'input_text', text: prompt }],
+          attachments: [
+            { file_id: fileId, tools: [{ type: 'file_search' }] },
+          ],
+        },
+      ],
+    }),
+  });
+  if (!res.ok) {
+    throw new Error('thread creation failed');
+  }
+  await res.json();
+}
+
+export async function processStatementFile(options: {
+  statementId: string;
+  bankId: string;
+  file: any;
+  apiKey: string;
+  systemPrompt: string;
+}) {
+  const { statementId, bankId, file, apiKey, systemPrompt } = options;
+  const db = await getDb();
+  try {
+    if (!apiKey) throw new Error('missing api key');
+    const fileId = await uploadFile(apiKey, file);
+    await db.runAsync(
+      'UPDATE statements SET external_file_id=? WHERE id=?',
+      fileId,
+      statementId
+    );
+    const bank = await getEntity(bankId);
+    const cats = await listExpenseCategories();
+    const prompt = [
+      systemPrompt,
+      bank ? bank.prompt : '',
+      'Expense categories: ' + cats.map((c) => c.label).join(', '),
+    ]
+      .filter(Boolean)
+      .join('\n');
+    await createThread(apiKey, fileId, prompt);
+    await db.runAsync('UPDATE statements SET status=? WHERE id=?', 'processed', statementId);
+  } catch (err) {
+    await db.runAsync('UPDATE statements SET status=? WHERE id=?', 'error', statementId);
+    throw err;
+  }
+}
+

--- a/lib/statements.ts
+++ b/lib/statements.ts
@@ -3,7 +3,7 @@ import { getDb } from './db';
 import { getEntity, listExpenseCategories } from './entities';
 import { createTransaction } from './transactions';
 
-export const STATEMENT_STATUSES = ['new', 'processed', 'reviewed', 'published'] as const;
+export const STATEMENT_STATUSES = ['new', 'processed', 'reviewed', 'published', 'error'] as const;
 export type StatementStatus = (typeof STATEMENT_STATUSES)[number];
 
 export interface Statement {

--- a/test-utils/sqliteMock.ts
+++ b/test-utils/sqliteMock.ts
@@ -160,12 +160,26 @@ export const sqliteMock = {
             if (col === 'reviewed_at') row.reviewed_at = value;
           });
         }
-      } else if (sql.startsWith('UPDATE statements SET status=')) {
-        const [status, reviewed_at, id] = params;
+      } else if (sql.startsWith('UPDATE statements SET external_file_id=')) {
+        const [external_file_id, id] = params;
         const row = tables.statements.find((r) => r.id === id);
         if (row) {
-          row.status = status;
-          row.reviewed_at = reviewed_at;
+          row.external_file_id = external_file_id;
+        }
+      } else if (sql.startsWith('UPDATE statements SET status=')) {
+        if (sql.includes('reviewed_at')) {
+          const [status, reviewed_at, id] = params;
+          const row = tables.statements.find((r) => r.id === id);
+          if (row) {
+            row.status = status;
+            row.reviewed_at = reviewed_at;
+          }
+        } else {
+          const [status, id] = params;
+          const row = tables.statements.find((r) => r.id === id);
+          if (row) {
+            row.status = status;
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- process uploaded statements by sending PDFs to OpenAI and creating assistant threads
- allow editing of global system prompt in settings and store OpenAI file IDs
- mark failed processing with new `error` status

## Testing
- `npm ci`
- `npm test` *(fails: Check Expo config schema; Check for legacy global CLI installed locally; Check that native modules use compatible support package versions for installed Expo SDK; Validate packages against React Native Directory package metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68b583461c188328b39ef281c0eb2b63