### PR TITLE
feat: handle pdf share intents

### DIFF
--- a/__tests__/share.test.ts
+++ b/__tests__/share.test.ts
@@ -1,0 +1,12 @@
+import { fileFromShareUrl } from '../lib/share';
+
+test('fileFromShareUrl returns asset', () => {
+  const asset = fileFromShareUrl('content://foo/bar/test.pdf');
+  expect(asset).toEqual(
+    expect.objectContaining({
+      uri: 'content://foo/bar/test.pdf',
+      name: 'test.pdf',
+      mimeType: 'application/pdf',
+    })
+  );
+});

--- a/app.json
+++ b/app.json
@@ -16,7 +16,14 @@
         "foregroundImage": "./assets/images/adaptive-icon.png",
         "backgroundColor": "#ffffff"
       },
-      "edgeToEdgeEnabled": true
+      "edgeToEdgeEnabled": true,
+      "intentFilters": [
+        {
+          "action": "SEND",
+          "category": ["BROWSABLE", "DEFAULT"],
+          "data": [{ "mimeType": "application/pdf" }]
+        }
+      ]
     },
     "web": {
       "bundler": "metro",

--- a/lib/share.ts
+++ b/lib/share.ts
@@ -1,0 +1,10 @@
+import type * as DocumentPicker from 'expo-document-picker';
+
+export function fileFromShareUrl(url: string): DocumentPicker.DocumentPickerAsset {
+  const name = decodeURIComponent(url.split('/').pop()?.split('?')[0] ?? 'shared.pdf');
+  return {
+    uri: url,
+    name,
+    mimeType: 'application/pdf',
+  } as DocumentPicker.DocumentPickerAsset;
+}

--- a/test-utils/sqliteMock.ts
+++ b/test-utils/sqliteMock.ts
@@ -174,6 +174,13 @@ export const sqliteMock = {
             row.status = status;
             row.reviewed_at = reviewed_at;
           }
+        } else if (sql.includes('processed_at')) {
+          const [status, processed_at, id] = params;
+          const row = tables.statements.find((r) => r.id === id);
+          if (row) {
+            row.status = status;
+            row.processed_at = processed_at;
+          }
         } else {
           const [status, id] = params;
           const row = tables.statements.find((r) => r.id === id);


### PR DESCRIPTION
## Summary
- enable handling of PDF share intents
- add share helper and tests
- fix sqlite mock update for processed statements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5bd40402c8328a2ef050c07778df6