### PR TITLE
feat: add income and savings management

### DIFF
--- a/__tests__/entities.test.ts
+++ b/__tests__/entities.test.ts
@@ -11,6 +11,8 @@ import {
   updateExpenseCategory,
   deleteExpenseCategory,
   listExpenseCategories,
+  createEntity,
+  deleteEntity,
 } from '../lib/entities';
 import { initDb } from '../lib/db';
 const sqlite = require('expo-sqlite');
@@ -24,6 +26,13 @@ test('seeds default expense categories', async () => {
   const expenses = await listEntities('expense');
   expect(expenses.find((c) => c.label === 'Food')).toBeTruthy();
   expect(expenses.find((c) => c.label === 'Groceries')).toBeTruthy();
+});
+
+test('seeds default income and savings categories', async () => {
+  const incomes = await listEntities('income');
+  const savings = await listEntities('savings');
+  expect(incomes.find((c) => c.label === 'Salary')).toBeTruthy();
+  expect(savings.find((c) => c.label === 'General')).toBeTruthy();
 });
 
 test('create, update, delete bank account', async () => {
@@ -46,6 +55,21 @@ test('create, update, delete bank account', async () => {
   await deleteBankAccount(created.id);
   const list = await listBankAccounts();
   expect(list.length).toBe(0);
+});
+
+test('create and delete income category', async () => {
+  const item = await createEntity({
+    label: 'Bonus',
+    category: 'income',
+    prompt: 'Bonus',
+    parentId: null,
+    currency: 'USD',
+  });
+  let list = await listEntities('income');
+  expect(list.find((c) => c.id === item.id)).toBeTruthy();
+  await deleteEntity(item.id);
+  list = await listEntities('income');
+  expect(list.find((c) => c.id === item.id)).toBeFalsy();
 });
 
 test('reject invalid currency', async () => {

--- a/app/income-savings/index.tsx
+++ b/app/income-savings/index.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useState } from 'react';
+import { ScrollView, View, Alert } from 'react-native';
+import { Button, IconButton, List, SegmentedButtons, Text, TextInput } from 'react-native-paper';
+import { useFocusEffect } from '@react-navigation/native';
+import { createEntity, deleteEntity, listEntities, Entity } from '../../lib/entities';
+
+export default function IncomeSavingsPage() {
+  const [type, setType] = useState<'income' | 'savings'>('income');
+  const [label, setLabel] = useState('');
+  const [income, setIncome] = useState<Entity[]>([]);
+  const [savings, setSavings] = useState<Entity[]>([]);
+
+  const load = useCallback(async () => {
+    const [inc, sav] = await Promise.all([
+      listEntities('income'),
+      listEntities('savings'),
+    ]);
+    setIncome(inc);
+    setSavings(sav);
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      load();
+    }, [load])
+  );
+
+  const handleAdd = async () => {
+    const trimmed = label.trim();
+    if (!trimmed) return;
+    await createEntity({
+      label: trimmed,
+      category: type,
+      prompt: trimmed,
+      parentId: null,
+      currency: 'USD',
+    });
+    setLabel('');
+    load();
+  };
+
+  const confirmDelete = (id: string, name: string) => {
+    Alert.alert('Delete?', `Remove ${name}?`, [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          await deleteEntity(id);
+          load();
+        },
+      },
+    ]);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={{ flexGrow: 1, padding: 16 }}>
+      <SegmentedButtons
+        value={type}
+        onValueChange={(v) => setType(v as 'income' | 'savings')}
+        buttons={[
+          { value: 'income', label: 'Income' },
+          { value: 'savings', label: 'Savings' },
+        ]}
+      />
+      <TextInput
+        label="Label"
+        value={label}
+        onChangeText={setLabel}
+        style={{ marginVertical: 8 }}
+      />
+      <Button mode="contained" onPress={handleAdd} disabled={!label.trim()}>
+        Add
+      </Button>
+      <View style={{ marginTop: 24 }}>
+        <Text style={{ marginBottom: 8, fontWeight: 'bold' }}>Income</Text>
+        {income.map((item) => (
+          <List.Item
+            key={item.id}
+            title={item.label}
+            right={() => (
+              <IconButton
+                icon="delete"
+                onPress={() => confirmDelete(item.id, item.label)}
+                accessibilityLabel={`Delete ${item.label}`}
+              />
+            )}
+          />
+        ))}
+        <View style={{ marginTop: 16 }}>
+          <Text style={{ marginBottom: 8, fontWeight: 'bold' }}>Savings</Text>
+          {savings.map((item) => (
+            <List.Item
+              key={item.id}
+              title={item.label}
+              right={() => (
+                <IconButton
+                  icon="delete"
+                  onPress={() => confirmDelete(item.id, item.label)}
+                  accessibilityLabel={`Delete ${item.label}`}
+                />
+              )}
+            />
+          ))}
+        </View>
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -300,6 +300,12 @@ export default function Index() {
                   {b.label}
                 </Chip>
               ))}
+              <IconButton
+                icon="plus"
+                size={20}
+                onPress={() => router.push('/bank-accounts/new')}
+                accessibilityLabel="Add bank account"
+              />
             </View>
           </ScrollView>
         </View>

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -29,8 +29,15 @@ function ManageButtons() {
       <Button
         mode="contained"
         onPress={() => router.push('/expense-categories')}
+        style={{ marginBottom: 8 }}
       >
         Manage expense categories
+      </Button>
+      <Button
+        mode="contained"
+        onPress={() => router.push('/income-savings')}
+      >
+        Manage income & savings
       </Button>
     </View>
   );

--- a/lib/defaultCategories.ts
+++ b/lib/defaultCategories.ts
@@ -96,3 +96,18 @@ export const DEFAULT_EXPENSE_CATEGORIES: CategorySeed[] = [
   },
 ];
 
+export const DEFAULT_INCOME_CATEGORIES = [
+  'Salary',
+  'Refunds',
+  'Sale',
+  'Gift',
+  'Invoices',
+  'Other',
+];
+
+export const DEFAULT_SAVINGS_CATEGORIES = [
+  'General',
+  'Investments',
+  'Other',
+];
+


### PR DESCRIPTION
## Summary
- add button to create bank account from index chips
- allow managing income and savings entities
- seed default income and savings categories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d25970dc8328846bb99227faf981