### PR TITLE
Refine settings and statement layouts

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -317,23 +317,36 @@ export default function Index() {
           ) : (
             <ScrollView>
                   {filtered.map((item) => (
-                    <Card key={item.id} style={{ marginBottom: 8 }} >
+                    <Card key={item.id} style={{ marginBottom: 8 }}>
                       <Card.Content>
-                        <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' }}>
-                          <TouchableOpacity style={{ flex: 1 }} onPress={() => router.push(`/statements/${item.id}`)}>
-                            <Text style={{ fontWeight: '700' }}>{formatRange(item.earliest, item.latest)}</Text>
-                            <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 6 }}>
-                              <Text style={{ paddingRight: 10}}>{item.bankLabel}</Text>
-                              <Chip mode="outlined" style={{ marginRight: 8 }}>{getStatusLabel(item)}</Chip>
-                              <Text style={{ color: 'gray' }}>{new Date(item.uploadDate).toLocaleDateString()}</Text>
-                            </View>
+                        <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                          <TouchableOpacity
+                            style={{ flex: 1 }}
+                            onPress={() => router.push(`/statements/${item.id}`)}
+                          >
+                            <Text style={{ fontWeight: '700' }}>
+                              {formatRange(item.earliest, item.latest)}
+                            </Text>
+                            <Text>
+                              {item.bankLabel} • {item.reviewedCount}/{item.transactionCount}
+                              {` reviewed`}
+                            </Text>
+                            <Text>Status: {getStatusLabel(item)}</Text>
                           </TouchableOpacity>
-                          <View style={{ alignItems: 'flex-end', marginLeft: 12 }}>
-                            <Text>{item.transactionCount} records</Text>
-                            <Text style={{ fontSize: 12, color: 'gray' }}>{item.reviewedCount}/{item.transactionCount} reviewed</Text>
-                            <View style={{ marginTop: 8 }}>
-                              <ActionMenu item={item} viewArchived={viewArchived} onRequestDelete={(id) => { setDeleteTarget(id); setConfirmVisible(true); }} refresh={refreshStatements} onReprocess={(stmt) => { setReprocessTarget(stmt); setReprocessConfirm(true); }} />
-                            </View>
+                          <View style={{ marginLeft: 12, justifyContent: 'center' }}>
+                            <ActionMenu
+                              item={item}
+                              viewArchived={viewArchived}
+                              onRequestDelete={(id) => {
+                                setDeleteTarget(id);
+                                setConfirmVisible(true);
+                              }}
+                              refresh={refreshStatements}
+                              onReprocess={(stmt) => {
+                                setReprocessTarget(stmt);
+                                setReprocessConfirm(true);
+                              }}
+                            />
                           </View>
                         </View>
                         {/* per-item progress removed - overall processing is shown in the upload modal */}

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import { Alert, ScrollView, View } from "react-native";
-import { Button, Text, TextInput, useTheme } from "react-native-paper";
+import {
+  Button,
+  Divider,
+  Text,
+  TextInput,
+  useTheme,
+} from "react-native-paper";
 import * as SecureStore from "expo-secure-store";
 import { useRouter } from "expo-router";
 import { DEFAULT_SYSTEM_PROMPT, OPENAI_KEY_STORAGE_KEY, SYSTEM_PROMPT_STORAGE_KEY } from "../lib/openai";
@@ -18,7 +24,10 @@ function formatDate(dateString: string | null) {
 function ManageButtons() {
   const router = useRouter();
   return (
-    <View style={{ marginBottom: 16 }}>
+    <View>
+      <Text variant="titleMedium" style={{ marginBottom: 8 }}>
+        Manage categories
+      </Text>
       <Button
         mode="contained"
         onPress={() => router.push('/bank-accounts')}
@@ -33,10 +42,7 @@ function ManageButtons() {
       >
         Manage expense categories
       </Button>
-      <Button
-        mode="contained"
-        onPress={() => router.push('/income-savings')}
-      >
+      <Button mode="contained" onPress={() => router.push('/income-savings')}>
         Manage income & savings
       </Button>
     </View>
@@ -104,73 +110,66 @@ const handleRemove = () => {
     ]);
 };
 
-  const handlePromptSave = async () => {
-    await SecureStore.setItemAsync(SYSTEM_PROMPT_STORAGE_KEY, prompt);
-    await setDefaultSharedPercent(sharedPercent);
-    Alert.alert('Settings saved.');
-  };
+const handlePromptSave = async () => {
+  await SecureStore.setItemAsync(SYSTEM_PROMPT_STORAGE_KEY, prompt);
+  await setDefaultSharedPercent(sharedPercent);
+  Alert.alert('Settings saved.');
+};
 
-  if (!hasKey || editing) {
+  const renderKeySection = () => {
+    if (!hasKey || editing) {
+      return (
+        <View>
+          <Text variant="titleMedium" style={{ marginBottom: 8 }}>
+            OpenAI API key
+          </Text>
+          <TextInput
+            mode="outlined"
+            secureTextEntry
+            placeholder="sk-..."
+            value={input}
+            onChangeText={(text) => {
+              setInput(text);
+              if (error) setError("");
+            }}
+            style={{ marginBottom: 8 }}
+          />
+          {error ? (
+            <Text style={{ color: theme.colors.error, marginBottom: 8 }}>
+              {error}
+            </Text>
+          ) : null}
+          <Button mode="contained" onPress={handleSave}>
+            {hasKey ? 'Save new key' : 'Save key'}
+          </Button>
+        </View>
+      );
+    }
+
     return (
-      <ScrollView contentContainerStyle={{ flexGrow: 1, padding: 20 }}>
-        <ManageButtons />
-        <Text style={{ marginBottom: 8 }}>OpenAI API key</Text>
-        <TextInput
-          mode="outlined"
-          secureTextEntry
-          placeholder="sk-..."
-          value={input}
-          onChangeText={(text) => {
-            setInput(text);
-            if (error) setError("");
-          }}
-          style={{ marginBottom: 8 }}
-        />
-        {error ? (
-          <Text style={{ color: theme.colors.error, marginBottom: 8 }}>{error}</Text>
-        ) : null}
-        <Button mode="contained" onPress={handleSave}>
-          {hasKey ? 'Save new key' : 'Save key'}
-        </Button>
-        <View style={{ height: 32 }} />
-        <Text style={{ marginBottom: 8 }}>System prompt</Text>
-        <TextInput
-          mode="outlined"
-          multiline
-          value={prompt}
-          onChangeText={setPrompt}
-          style={{ marginBottom: 8 }}
-        />
-        <Text style={{ marginBottom: 8 }}>Default shared percentage</Text>
-        <TextInput
-          mode="outlined"
-          keyboardType="numeric"
-          value={String(sharedPercent)}
-          onChangeText={(t) => setSharedPercent(Number(t) || 0)}
-          style={{ marginBottom: 4 }}
-        />
-        <Text style={{ fontSize: 12, color: 'gray', marginBottom: 8 }}>
-          This will be the default shared value for all entries created.
+      <View>
+        <Text variant="titleMedium" style={{ marginBottom: 8 }}>
+          OpenAI API key
         </Text>
-        <Button onPress={handlePromptSave}>Save settings</Button>
-      </ScrollView>
+        <Text style={{ marginBottom: 16 }}>
+          Key saved • Last updated {formatDate(updatedAt)}
+        </Text>
+        <Button mode="contained" onPress={() => setEditing(true)}>
+          Replace key
+        </Button>
+        <View style={{ height: 8 }} />
+        <Button onPress={handleRemove}>Remove key</Button>
+      </View>
     );
-  }
+  };
 
   return (
     <ScrollView contentContainerStyle={{ flexGrow: 1, padding: 20 }}>
       <ManageButtons />
-      <Text style={{ marginBottom: 8 }}>OpenAI API key</Text>
-      <Text style={{ marginBottom: 16 }}>
-        Key saved • Last updated {formatDate(updatedAt)}
+      <Divider style={{ marginVertical: 16 }} />
+      <Text variant="titleMedium" style={{ marginBottom: 8 }}>
+        System prompt
       </Text>
-      <Button mode="contained" onPress={() => setEditing(true)}>
-        Replace key
-      </Button>
-      <View style={{ height: 8 }} />
-      <Button onPress={handleRemove}>Remove key</Button>
-      <View style={{ height: 32 }} />
-      <Text style={{ marginBottom: 8 }}>System prompt</Text>
       <TextInput
         mode="outlined"
         multiline
@@ -178,7 +177,10 @@ const handleRemove = () => {
         onChangeText={setPrompt}
         style={{ marginBottom: 8 }}
       />
-      <Text style={{ marginBottom: 8 }}>Default shared percentage</Text>
+      <Divider style={{ marginVertical: 16 }} />
+      <Text variant="titleMedium" style={{ marginBottom: 8 }}>
+        Default shared percentage
+      </Text>
       <TextInput
         mode="outlined"
         keyboardType="numeric"
@@ -190,6 +192,8 @@ const handleRemove = () => {
         This will be the default shared value for all entries created.
       </Text>
       <Button onPress={handlePromptSave}>Save settings</Button>
+      <Divider style={{ marginVertical: 16 }} />
+      {renderKeySection()}
     </ScrollView>
   );
 }

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -205,7 +205,7 @@ export default function StatementTransactions() {
       {meta && nf && (
         <View style={{ marginBottom: 16 }}>
           <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-            <View>
+            <View style={{ flex: 1 }}>
               <Text
                 onPress={() => {
                   setPromptEdit(meta.bankPrompt);
@@ -222,7 +222,7 @@ export default function StatementTransactions() {
               <Text>Transactions: {meta.count}</Text>
               <Text>Total Amount: {nf.format(progress.total)}</Text>
             </View>
-            <View style={{ alignItems: 'flex-end' }}>
+            <View style={{ flex: 1, alignItems: 'flex-end' }}>
               <Text>
                 Reviewed: {reviewedCount} / {meta.count} ({countPct.toFixed(1)}%)
               </Text>


### PR DESCRIPTION
## Summary
- group settings into labeled sections with dividers and move OpenAI key to bottom
- prevent statement metadata from overflowing off-screen
- redesign statement cards to show key info in three rows with centered action menu

## Testing
- `npm ci`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6098280b88328a3486db54f0a52ea