### PR TITLE
feat: add analysis screen with expense chart

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -1,0 +1,32 @@
+jest.mock('expo-sqlite', () => require('../test-utils/sqliteMock').sqliteMock);
+
+import { createStatement } from '../lib/statements';
+import { createExpenseCategory } from '../lib/entities';
+import { createTransaction } from '../lib/transactions';
+import { summarizeExpensesByParent } from '../lib/analytics';
+import sqliteMock from '../test-utils/sqliteMock';
+
+describe('analytics', () => {
+  beforeEach(() => {
+    // @ts-ignore
+    sqliteMock.__reset();
+  });
+
+  it('summarizes expenses by top-level parent', async () => {
+    const food = await createExpenseCategory({ label: 'Food', prompt: 'Food', parentId: null });
+    const grocery = await createExpenseCategory({ label: 'Groceries', prompt: 'Groceries', parentId: food.id });
+    const transport = await createExpenseCategory({ label: 'Transport', prompt: 'Transport', parentId: null });
+    const bus = await createExpenseCategory({ label: 'Bus', prompt: 'Bus', parentId: transport.id });
+    const stmt = await createStatement({ bankId: '1', uploadDate: 1, status: 'new' });
+    const now = Date.now();
+    await createTransaction({ statementId: stmt.id, recipientId: grocery.id, senderId: null, createdAt: now - 1000, amount: 100, currency: 'USD', shared: false });
+    await createTransaction({ statementId: stmt.id, recipientId: bus.id, senderId: null, createdAt: now - 500, amount: 50, currency: 'USD', shared: false });
+    await createTransaction({ statementId: stmt.id, recipientId: bus.id, senderId: null, createdAt: now - 250, amount: 25, currency: 'USD', shared: false });
+
+    const res = await summarizeExpensesByParent(now - 2000, now);
+    expect(res).toEqual([
+      { parentId: food.id, parentLabel: 'Food', total: 100 },
+      { parentId: transport.id, parentLabel: 'Transport', total: 75 },
+    ]);
+  });
+});

--- a/app/analysis.tsx
+++ b/app/analysis.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { SegmentedButtons, Text } from 'react-native-paper';
+import Svg, { Rect, Text as SvgText } from 'react-native-svg';
+import { summarizeExpensesByParent, ExpenseSummary } from '../lib/analytics';
+
+type RangeKey = '7d' | '1m' | 'qtd' | 'ytd';
+
+function getRange(key: RangeKey): { start: number; end: number } {
+  const now = new Date();
+  const end = now.getTime();
+  if (key === '7d') {
+    const start = new Date(end - 7 * 24 * 60 * 60 * 1000).getTime();
+    return { start, end };
+  }
+  if (key === '1m') {
+    const startDate = new Date(now.getFullYear(), now.getMonth() - 1, 1);
+    const start = startDate.getTime();
+    const endDate = new Date(now.getFullYear(), now.getMonth(), 1);
+    return { start, end: endDate.getTime() };
+  }
+  if (key === 'qtd') {
+    const quarter = Math.floor(now.getMonth() / 3);
+    const startDate = new Date(now.getFullYear(), quarter * 3, 1);
+    return { start: startDate.getTime(), end };
+  }
+  const startDate = new Date(now.getFullYear(), 0, 1);
+  return { start: startDate.getTime(), end };
+}
+
+export default function Analysis() {
+  const [range, setRange] = useState<RangeKey>('ytd');
+  const [data, setData] = useState<ExpenseSummary[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const { start, end } = getRange(range);
+      const res = await summarizeExpensesByParent(start, end);
+      setData(res);
+    })();
+  }, [range]);
+
+  const max = data.reduce((m, d) => Math.max(m, d.total), 0);
+  const barWidth = 40;
+  const gap = 20;
+  const chartHeight = 180;
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <View style={{ height: chartHeight + 20 }}>
+        {data.length === 0 ? (
+          <Text>No data</Text>
+        ) : (
+          <Svg height={chartHeight + 20} width={(barWidth + gap) * data.length}>
+            {data.map((d, i) => {
+              const h = max === 0 ? 0 : (d.total / max) * chartHeight;
+              const x = i * (barWidth + gap);
+              return (
+                <>
+                  <Rect
+                    key={`bar-${d.parentId}`}
+                    x={x}
+                    y={chartHeight - h}
+                    width={barWidth}
+                    height={h}
+                    fill="#6200ee"
+                  />
+                  <SvgText
+                    key={`label-${d.parentId}`}
+                    x={x + barWidth / 2}
+                    y={chartHeight + 10}
+                    fontSize="10"
+                    fill="black"
+                    textAnchor="middle"
+                  >
+                    {d.parentLabel}
+                  </SvgText>
+                </>
+              );
+            })}
+          </Svg>
+        )}
+      </View>
+      <SegmentedButtons
+        value={range}
+        onValueChange={(v) => setRange(v as RangeKey)}
+        buttons={[
+          { value: '7d', label: 'Last 7 days' },
+          { value: '1m', label: 'Last month' },
+          { value: 'qtd', label: 'Quarter to date' },
+          { value: 'ytd', label: 'Year to date' },
+        ]}
+        style={{ marginTop: 16 }}
+      />
+    </View>
+  );
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -13,6 +13,7 @@ import { archiveStatement, createStatement, deleteStatement, listStatementsWithM
 import { fileFromShareUrl } from '../lib/share';
 import Settings from './settings';
 import UploadModal from './UploadModal';
+import Analysis from './analysis';
 import { useFocusEffect } from '@react-navigation/native';
 
 function StatusRow({ item }: { item: StatementMeta }) {
@@ -99,7 +100,8 @@ export default function Index() {
   const router = useRouter();
   const [navIndex, setNavIndex] = useState(0);
   const [navRoutes] = useState([
-    { key: 'statements', title: 'Statements', icon: 'file-document' },
+    { key: 'import', title: 'Import', icon: 'file-import' },
+    { key: 'analysis', title: 'Analysis', icon: 'chart-bar' },
     { key: 'settings', title: 'Settings', icon: 'cog' },
   ]);
   const [statements, setStatements] = useState<StatementMeta[]>([]);
@@ -237,7 +239,7 @@ export default function Index() {
     return () => sub.remove();
   }, []);
 
-  const StatementsRoute = () => {
+  const ImportRoute = () => {
   const [viewArchived, setViewArchived] = useState<'current' | 'archived'>('current');
     const [confirmVisible, setConfirmVisible] = useState(false);
     const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
@@ -498,8 +500,15 @@ export default function Index() {
     </View>
   );
 
+  const AnalysisRoute = () => (
+    <View style={{ flex: 1 }}>
+      <Analysis />
+    </View>
+  );
+
   const renderScene = BottomNavigation.SceneMap({
-    statements: StatementsRoute,
+    import: ImportRoute,
+    analysis: AnalysisRoute,
     settings: SettingsRoute,
   });
 

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,45 @@
+import { getDb } from './db';
+import { listEntities, Entity } from './entities';
+
+export interface ExpenseSummary {
+  parentId: string;
+  parentLabel: string;
+  total: number;
+}
+
+function buildParentMap(categories: Entity[]) {
+  const map = new Map<string, Entity>();
+  categories.forEach((c) => map.set(c.id, c));
+  return map;
+}
+
+function resolveTopParent(map: Map<string, Entity>, id: string): Entity | null {
+  let current = map.get(id) || null;
+  if (!current) return null;
+  while (current.parentId) {
+    const next = map.get(current.parentId);
+    if (!next) break;
+    current = next;
+  }
+  return current;
+}
+
+export async function summarizeExpensesByParent(start: number, end: number): Promise<ExpenseSummary[]> {
+  const db = await getDb();
+  const rows: any[] = await db.getAllAsync('SELECT * FROM transactions');
+  const categories = await listEntities('expense');
+  const catMap = buildParentMap(categories);
+  const totals = new Map<string, ExpenseSummary>();
+
+  for (const t of rows) {
+    if (t.created_at < start || t.created_at > end) continue;
+    if (!t.recipient_id) continue;
+    const parent = resolveTopParent(catMap, String(t.recipient_id));
+    if (!parent) continue;
+    const existing = totals.get(parent.id) || { parentId: parent.id, parentLabel: parent.label, total: 0 };
+    existing.total += t.amount;
+    totals.set(parent.id, existing);
+  }
+
+  return Array.from(totals.values()).sort((a, b) => b.total - a.total);
+}

--- a/test-utils/sqliteMock.ts
+++ b/test-utils/sqliteMock.ts
@@ -29,6 +29,11 @@ export const sqliteMock = {
           .filter((t) => t.statement_id === param)
           .sort((a, b) => b.created_at - a.created_at);
       }
+      if (sql.startsWith('SELECT * FROM transactions')) {
+        return [...tables.transactions].sort(
+          (a, b) => b.created_at - a.created_at
+        );
+      }
       return [];
     },
     getFirstAsync: async (sql: string, param?: any) => {


### PR DESCRIPTION
## Summary
- rename statements tab to import with import icon
- add analysis tab displaying expense bar chart with time filters
- provide analytics utility to summarize expenses by top-level parent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b614fc3f488328abcbad257bcba91e