### PR TITLE
Reset learn modal after close and guard empty prompts

### DIFF
--- a/__tests__/learning.test.ts
+++ b/__tests__/learning.test.ts
@@ -31,5 +31,14 @@ describe('learnFromTransactions', () => {
       learnFromTransactions({ bankPrompt: '', transactions: [], apiKey: 'sk' })
     ).rejects.toThrow();
   });
+
+  it('throws when API returns empty prompt', async () => {
+    const fakeFetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ output_text: '' }) });
+    // @ts-ignore
+    global.fetch = fakeFetch;
+    await expect(
+      learnFromTransactions({ bankPrompt: 'old', transactions: [], apiKey: 'sk' })
+    ).rejects.toThrow('empty prompt');
+  });
 });
 

--- a/app/LearnModal.tsx
+++ b/app/LearnModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ScrollView, View, TouchableOpacity } from 'react-native';
 import { Button, Checkbox, Modal, Portal, ProgressBar, Text } from 'react-native-paper';
 import * as SecureStore from 'expo-secure-store';
@@ -31,6 +31,20 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
   const [log, setLog] = useState('');
   const [controller, setController] = useState<AbortController | null>(null);
   const [completed, setCompleted] = useState(false);
+
+  const reset = () => {
+    controller?.abort();
+    setScreen('select');
+    setSelected(new Set());
+    setProgress(0);
+    setLog('');
+    setController(null);
+    setCompleted(false);
+  };
+
+  useEffect(() => {
+    if (!visible) reset();
+  }, [visible]);
 
   const nf = new Intl.NumberFormat(undefined, { style: 'currency', currency: bank.currency || 'USD' });
 

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -442,9 +442,10 @@ export async function learnFromTransactions(options: {
   const json = await res.json();
   onProgress?.(0.75);
   onLog?.('response received');
-  const output = json.output_text || '';
+  const output = (json.output_text || '').trim();
   onProgress?.(1);
   onLog?.('done');
+  if (!output) throw new Error('empty prompt');
   return output;
 }
 


### PR DESCRIPTION
## Summary
- Reset Learn modal state when hidden, aborting any active request so new transactions can be selected later
- Reject empty prompts from learnFromTransactions to avoid invalid bank updates
- Add regression test for empty prompt responses

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b616555a2c8328a6e004c53d9962c2