### PR TITLE
Use OpenAI SDK for learning

### DIFF
--- a/__tests__/learning.test.ts
+++ b/__tests__/learning.test.ts
@@ -1,17 +1,23 @@
 jest.mock('expo-sqlite', () => require('../test-utils/sqliteMock').sqliteMock);
 
+const mockResponsesCreate = jest.fn();
+jest.mock('openai', () => {
+  return jest.fn().mockImplementation(() => ({
+    responses: { create: mockResponsesCreate },
+  }));
+});
+
 import { learnFromTransactions } from '../lib/openai';
 
 describe('learnFromTransactions', () => {
   beforeEach(() => {
     // @ts-ignore
     require('expo-sqlite').__reset();
+    mockResponsesCreate.mockReset();
   });
 
   it('returns updated prompt', async () => {
-    const fakeFetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ output_text: 'new prompt' }) });
-    // @ts-ignore
-    global.fetch = fakeFetch;
+    mockResponsesCreate.mockResolvedValue({ output_text: 'new prompt' });
     const res = await learnFromTransactions({
       bankPrompt: 'old',
       transactions: [
@@ -20,25 +26,23 @@ describe('learnFromTransactions', () => {
       apiKey: 'sk',
     });
     expect(res).toBe('new prompt');
-    expect(fakeFetch).toHaveBeenCalled();
+    expect(mockResponsesCreate).toHaveBeenCalled();
   });
 
   it('throws on error response', async () => {
-    const fakeFetch = jest.fn().mockResolvedValue({ ok: false, json: async () => ({}) });
-    // @ts-ignore
-    global.fetch = fakeFetch;
+    mockResponsesCreate.mockRejectedValue(new Error('bad'));
     await expect(
       learnFromTransactions({ bankPrompt: '', transactions: [], apiKey: 'sk' })
     ).rejects.toThrow();
+    expect(mockResponsesCreate).toHaveBeenCalled();
   });
 
   it('throws when API returns empty prompt', async () => {
-    const fakeFetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ output_text: '' }) });
-    // @ts-ignore
-    global.fetch = fakeFetch;
+    mockResponsesCreate.mockResolvedValue({ output_text: '' });
     await expect(
       learnFromTransactions({ bankPrompt: 'old', transactions: [], apiKey: 'sk' })
     ).rejects.toThrow('empty prompt');
+    expect(mockResponsesCreate).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- switch learnFromTransactions to use OpenAI SDK with detailed logging
- adapt tests to mock OpenAI SDK responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b61828d7088328855a37665a6f7a3c