### PR TITLE
feat: enhance transaction management

### DIFF
--- a/app/LearnModal.tsx
+++ b/app/LearnModal.tsx
@@ -2,7 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { ScrollView, View, TouchableOpacity } from 'react-native';
 import { Button, Checkbox, Modal, Portal, ProgressBar, Text } from 'react-native-paper';
 import * as SecureStore from 'expo-secure-store';
-import { OPENAI_KEY_STORAGE_KEY, learnFromTransactions } from '../lib/openai';
+import {
+  OPENAI_KEY_STORAGE_KEY,
+  LEARN_PROMPT_STORAGE_KEY,
+  DEFAULT_LEARN_PROMPT,
+  learnFromTransactions,
+} from '../lib/openai';
 import { updateBankAccount } from '../lib/entities';
 
 export type LearnTxn = {
@@ -60,6 +65,9 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
   const start = async () => {
     setScreen('progress');
     const apiKey = await SecureStore.getItemAsync(OPENAI_KEY_STORAGE_KEY);
+    const base =
+      (await SecureStore.getItemAsync(LEARN_PROMPT_STORAGE_KEY)) ??
+      DEFAULT_LEARN_PROMPT;
     const list = transactions
       .filter((t) => selected.has(t.id))
       .map((t) => ({
@@ -74,6 +82,7 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
     try {
       const newPrompt = await learnFromTransactions({
         bankPrompt: bank.prompt,
+        basePrompt: base,
         transactions: list,
         apiKey: apiKey || '',
         onProgress: (p) => setProgress(p),

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Alert, ScrollView, View } from "react-native";
+import { Alert, ScrollView, View, Keyboard } from "react-native";
 import {
   Button,
   Divider,
@@ -9,7 +9,13 @@ import {
 } from "react-native-paper";
 import * as SecureStore from "expo-secure-store";
 import { useRouter } from "expo-router";
-import { DEFAULT_SYSTEM_PROMPT, OPENAI_KEY_STORAGE_KEY, SYSTEM_PROMPT_STORAGE_KEY } from "../lib/openai";
+import {
+  DEFAULT_SYSTEM_PROMPT,
+  DEFAULT_LEARN_PROMPT,
+  OPENAI_KEY_STORAGE_KEY,
+  SYSTEM_PROMPT_STORAGE_KEY,
+  LEARN_PROMPT_STORAGE_KEY,
+} from "../lib/openai";
 import { DEFAULT_SHARED_PERCENT, getDefaultSharedPercent, setDefaultSharedPercent } from "../lib/settings";
 
 const UPDATED_AT_KEY = "openai_api_key_updated_at";
@@ -56,6 +62,7 @@ export default function Settings() {
   const [updatedAt, setUpdatedAt] = useState<string | null>(null);
   const [editing, setEditing] = useState(false);
   const [prompt, setPrompt] = useState("");
+  const [learnPrompt, setLearnPrompt] = useState("");
   const [sharedPercent, setSharedPercent] = useState<number>(DEFAULT_SHARED_PERCENT);
   const theme = useTheme();
 
@@ -66,10 +73,14 @@ export default function Settings() {
       const storedPrompt = await SecureStore.getItemAsync(
         SYSTEM_PROMPT_STORAGE_KEY
       );
+      const storedLearnPrompt = await SecureStore.getItemAsync(
+        LEARN_PROMPT_STORAGE_KEY
+      );
       const percent = await getDefaultSharedPercent();
       setHasKey(!!existing);
       setUpdatedAt(updated);
       setPrompt(storedPrompt ?? DEFAULT_SYSTEM_PROMPT);
+      setLearnPrompt(storedLearnPrompt ?? DEFAULT_LEARN_PROMPT);
       setSharedPercent(percent);
     })();
   }, []);
@@ -110,11 +121,12 @@ const handleRemove = () => {
     ]);
 };
 
-const handlePromptSave = async () => {
-  await SecureStore.setItemAsync(SYSTEM_PROMPT_STORAGE_KEY, prompt);
-  await setDefaultSharedPercent(sharedPercent);
-  Alert.alert('Settings saved.');
-};
+  const handlePromptSave = async () => {
+    await SecureStore.setItemAsync(SYSTEM_PROMPT_STORAGE_KEY, prompt);
+    await SecureStore.setItemAsync(LEARN_PROMPT_STORAGE_KEY, learnPrompt);
+    await setDefaultSharedPercent(sharedPercent);
+    Alert.alert('Settings saved.');
+  };
 
   const renderKeySection = () => {
     if (!hasKey || editing) {
@@ -175,6 +187,20 @@ const handlePromptSave = async () => {
         multiline
         value={prompt}
         onChangeText={setPrompt}
+        style={{ marginBottom: 8 }}
+      />
+      <Button onPress={() => Keyboard.dismiss()} style={{ marginBottom: 8 }}>
+        Dismiss keyboard
+      </Button>
+      <Divider style={{ marginVertical: 16 }} />
+      <Text variant="titleMedium" style={{ marginBottom: 8 }}>
+        Learn mode prompt
+      </Text>
+      <TextInput
+        mode="outlined"
+        multiline
+        value={learnPrompt}
+        onChangeText={setLearnPrompt}
         style={{ marginBottom: 8 }}
       />
       <Divider style={{ marginVertical: 16 }} />


### PR DESCRIPTION
## Summary
- always show parent and child entity names with a dash in transaction and learn mode views
- add settings for learn mode prompt and keyboard dismissal
- replace statement options menu with FAB actions including reprocessing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b61cd8f550832894a8d32213fb37f0