### PR TITLE
feat: improve learn mode prompts

### DIFF
--- a/__tests__/openai.test.ts
+++ b/__tests__/openai.test.ts
@@ -122,5 +122,26 @@ describe('openai processing', () => {
     const input2 = createResponseMock.mock.calls[0][0].input;
     expect(input2.startsWith(`${DEFAULT_LEARN_PROMPT}\nbank`)).toBe(true);
   });
+
+  test('learnFromTransactions logs prompt with transactions', async () => {
+    const logs: string[] = [];
+    await learnFromTransactions({
+      bankPrompt: 'bank',
+      basePrompt: 'base',
+      transactions: [
+        {
+          description: 'd',
+          amount: 1,
+          shared: false,
+          category: 'c',
+          type: 'debit',
+        },
+      ],
+      apiKey: 'sk',
+      onLog: (m) => logs.push(m),
+    });
+    const expected = 'base\nbank\nTxn 1: description="d" amount=1 shared=false category="c" type=debit\n\n';
+    expect(logs).toContain(expected);
+  });
 });
 

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -411,13 +411,13 @@ export default function StatementTransactions() {
         <LearnModal
           visible={learnVisible}
           bank={{ id: meta.bankId, prompt: meta.bankPrompt, label: meta.bank, currency: meta.currency }}
-          transactions={transactions as unknown as LearnTxn[]}
+          transactions={sorted as unknown as LearnTxn[]}
           onDismiss={() => setLearnVisible(false)}
           onComplete={(p) => setMeta((m) => (m ? { ...m, bankPrompt: p } : m))}
         />
       )}
       <Portal>
-        <Modal visible={promptModal} onDismiss={() => setPromptModal(false)} contentContainerStyle={{ backgroundColor: theme.colors.background, padding: 12, margin: 20, borderRadius: 12 }}>
+        <Modal visible={promptModal} onDismiss={() => setPromptModal(false)} contentContainerStyle={{ backgroundColor: theme.colors.background, padding: 12, margin: 20, borderRadius: 12, height: 300 }}>
           <Text style={{ marginBottom: 8 }}>Edit bank prompt</Text>
           <TextInput
             mode="outlined"

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -430,6 +430,7 @@ export async function learnFromTransactions(options: {
     `Txn ${i + 1}: description="${t.description ?? ''}" amount=${t.amount} shared=${t.shared} category="${t.category ?? ''}" type=${t.type}`
   );
   const prompt = [learnPrompt, bankPrompt, ...txLines].join('\n');
+  onLog?.(prompt + '\n\n');
   onProgress?.(0.25);
   onLog?.('prompt built; initializing OpenAI client');
   console.log('learnFromTransactions: prompt built');


### PR DESCRIPTION
## Summary
- show built prompt in learn mode logs
- sort learn selection like transactions view
- fix bank prompt modal height in statements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6a258b3608328b4acca83aed3deed