### PR TITLE
fix: keep prompt modal visible and learn with category ids

### DIFF
--- a/__tests__/learning.test.ts
+++ b/__tests__/learning.test.ts
@@ -8,6 +8,7 @@ jest.mock('openai', () => {
 });
 
 import { learnFromTransactions } from '../lib/openai';
+import { prepareLearningTransactions, LearnTxn } from '../lib/learn';
 
 describe('learnFromTransactions', () => {
   beforeEach(() => {
@@ -43,6 +44,39 @@ describe('learnFromTransactions', () => {
       learnFromTransactions({ bankPrompt: 'old', transactions: [], apiKey: 'sk' })
     ).rejects.toThrow('empty prompt');
     expect(mockResponsesCreate).toHaveBeenCalled();
+  });
+});
+
+describe('prepareLearningTransactions', () => {
+  it('uses category ids and types correctly', () => {
+    const txns: LearnTxn[] = [
+      {
+        id: '1',
+        description: 'd',
+        amount: 1,
+        shared: false,
+        senderId: 'bank',
+        recipientId: 'cat1',
+        senderLabel: 'Bank',
+        recipientLabel: 'Food',
+      },
+      {
+        id: '2',
+        description: 'e',
+        amount: 2,
+        shared: true,
+        senderId: 'cat2',
+        recipientId: 'bank',
+        senderLabel: 'Salary',
+        recipientLabel: 'Bank',
+      },
+    ];
+    const selected = new Set(['1', '2']);
+    const list = prepareLearningTransactions('bank', txns, selected);
+    expect(list).toEqual([
+      { description: 'd', amount: 1, shared: false, category: 'cat1', type: 'debit' },
+      { description: 'e', amount: 2, shared: true, category: 'cat2', type: 'credit' },
+    ]);
   });
 });
 

--- a/app/LearnModal.tsx
+++ b/app/LearnModal.tsx
@@ -9,17 +9,7 @@ import {
   learnFromTransactions,
 } from '../lib/openai';
 import { updateBankAccount } from '../lib/entities';
-
-export type LearnTxn = {
-  id: string;
-  description: string | null;
-  amount: number;
-  shared: boolean;
-  senderId: string | null;
-  recipientId: string | null;
-  senderLabel: string;
-  recipientLabel: string;
-};
+import { LearnTxn, prepareLearningTransactions } from '../lib/learn';
 
 export type LearnModalProps = {
   visible: boolean;
@@ -68,15 +58,7 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
     const base =
       (await SecureStore.getItemAsync(LEARN_PROMPT_STORAGE_KEY)) ??
       DEFAULT_LEARN_PROMPT;
-    const list = transactions
-      .filter((t) => selected.has(t.id))
-      .map((t) => ({
-        description: t.description,
-        amount: t.amount,
-        shared: t.shared,
-        category: t.senderId === bank.id ? t.recipientLabel : t.senderLabel,
-        type: t.senderId === bank.id ? 'debit' as const : 'credit' as const,
-      }));
+    const list = prepareLearningTransactions(bank.id, transactions, selected);
     const ac = new AbortController();
     setController(ac);
     try {

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -1,6 +1,14 @@
 import { useLocalSearchParams, useNavigation } from 'expo-router';
 import { useEffect, useState, useMemo } from 'react';
-import { Alert, ScrollView, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import {
+  Alert,
+  ScrollView,
+  TouchableOpacity,
+  useWindowDimensions,
+  View,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
 import {
   Button,
   Card,
@@ -32,7 +40,8 @@ import {
   markAllTransactionsReviewed,
 } from '../../lib/transactions';
 import { getDefaultSharedPercent } from '../../lib/settings';
-import LearnModal, { LearnTxn } from '../LearnModal';
+import LearnModal from '../LearnModal';
+import { LearnTxn } from '../../lib/learn';
 import * as SecureStore from 'expo-secure-store';
 import {
   OPENAI_KEY_STORAGE_KEY,
@@ -417,22 +426,45 @@ export default function StatementTransactions() {
         />
       )}
       <Portal>
-        <Modal visible={promptModal} onDismiss={() => setPromptModal(false)} contentContainerStyle={{ backgroundColor: theme.colors.background, padding: 12, margin: 20, borderRadius: 12, height: 300 }}>
-          <Text style={{ marginBottom: 8 }}>Edit bank prompt</Text>
-          <TextInput
-            mode="outlined"
-            multiline
-            value={promptEdit}
-            onChangeText={setPromptEdit}
-            style={{ marginBottom: 8 }}
-          />
-          <Button onPress={async () => {
-            if (!meta) return;
-            await updateBankAccount(meta.bankId, { label: meta.bank, prompt: promptEdit, currency: meta.currency });
-            setMeta((m) => m ? { ...m, bankPrompt: promptEdit } : m);
-            setPromptModal(false);
-          }}>Save</Button>
-        </Modal>
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={{ flex: 1 }}
+        >
+          <Modal
+            visible={promptModal}
+            onDismiss={() => setPromptModal(false)}
+            contentContainerStyle={{
+              backgroundColor: theme.colors.background,
+              padding: 12,
+              margin: 20,
+              borderRadius: 12,
+              height: 300,
+            }}
+          >
+            <Text style={{ marginBottom: 8 }}>Edit bank prompt</Text>
+            <TextInput
+              mode="outlined"
+              multiline
+              value={promptEdit}
+              onChangeText={setPromptEdit}
+              style={{ marginBottom: 8 }}
+            />
+            <Button
+              onPress={async () => {
+                if (!meta) return;
+                await updateBankAccount(meta.bankId, {
+                  label: meta.bank,
+                  prompt: promptEdit,
+                  currency: meta.currency,
+                });
+                setMeta((m) => (m ? { ...m, bankPrompt: promptEdit } : m));
+                setPromptModal(false);
+              }}
+            >
+              Save
+            </Button>
+          </Modal>
+        </KeyboardAvoidingView>
         <Modal
           visible={processingVisible}
           dismissable={false}

--- a/lib/learn.ts
+++ b/lib/learn.ts
@@ -1,0 +1,26 @@
+export type LearnTxn = {
+  id: string;
+  description: string | null;
+  amount: number;
+  shared: boolean;
+  senderId: string | null;
+  recipientId: string | null;
+  senderLabel: string;
+  recipientLabel: string;
+};
+
+export function prepareLearningTransactions(
+  bankId: string,
+  transactions: LearnTxn[],
+  selected: Set<string>
+) {
+  return transactions
+    .filter((t) => selected.has(t.id))
+    .map((t) => ({
+      description: t.description,
+      amount: t.amount,
+      shared: t.shared,
+      category: t.senderId === bankId ? t.recipientId : t.senderId,
+      type: t.senderId === bankId ? ('debit' as const) : ('credit' as const),
+    }));
+}


### PR DESCRIPTION
## Summary
- keep bank prompt editor above keyboard
- learn mode now sends category ids instead of labels
- cover learning transaction mapping with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6b714e04c8328b4459e139822fd27