### PR TITLE
Improve processing and prompt editing modals

### DIFF
--- a/app/LearnModal.tsx
+++ b/app/LearnModal.tsx
@@ -72,7 +72,7 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
         signal: ac.signal,
       });
       await updateBankAccount(bank.id, { label: bank.label, prompt: newPrompt, currency: bank.currency });
-      setLog((l) => l + 'saved prompt\n');
+      setLog((l) => l + 'saved prompt\n' + newPrompt + '\n');
       setCompleted(true);
       onComplete(newPrompt);
     } catch (e: any) {
@@ -130,7 +130,9 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
             </View>
             <View style={{ marginTop: 12, flexDirection: 'row', justifyContent: 'space-between' }}>
               <Button mode="outlined" onPress={abort}>Abort</Button>
-              <Button mode="contained" onPress={onDismiss}>{completed ? 'Close' : 'Wait'}</Button>
+              <Button mode="contained" onPress={onDismiss} disabled={!completed}>
+                {completed ? 'Close' : 'Wait'}
+              </Button>
             </View>
           </View>
         )}

--- a/app/ProcessingModal.tsx
+++ b/app/ProcessingModal.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { ScrollView, View } from 'react-native';
+import { Button, Modal, ProgressBar, Text, useTheme } from 'react-native-paper';
+
+export type ProcessingModalProps = {
+  visible: boolean;
+  title?: string;
+  log: string;
+  progress: number;
+  done: boolean;
+  onClose: () => void;
+  onAbort?: () => void;
+};
+
+export default function ProcessingModal({
+  visible,
+  title = 'Processing statement',
+  log,
+  progress,
+  done,
+  onClose,
+  onAbort,
+}: ProcessingModalProps) {
+  const theme = useTheme();
+  return (
+    <Modal
+      visible={visible}
+      dismissable={false}
+      contentContainerStyle={{
+        flex: 1,
+        padding: 16,
+        paddingTop: 64,
+        backgroundColor: theme.colors.background,
+        height: '100%',
+      }}
+    >
+      <View style={{ flex: 1 }}>
+        <Text style={{ fontSize: 20, fontWeight: '700', marginBottom: 12 }}>{title}</Text>
+        <Text style={{ marginBottom: 12, color: 'gray' }}>
+          Processing can take between 1-2 minutes. The log below shows processing updates.
+        </Text>
+        <View style={{ marginBottom: 12 }}>
+          <ProgressBar progress={progress} />
+        </View>
+        <View style={{ flex: 1, borderWidth: 1, borderColor: '#ddd', padding: 8, borderRadius: 6 }}>
+          <ScrollView>
+            <Text selectable style={{ fontFamily: 'monospace', fontSize: 12 }}>
+              {log}
+            </Text>
+          </ScrollView>
+        </View>
+        <View
+          style={{
+            marginTop: 12,
+            flexDirection: 'row',
+            justifyContent: onAbort ? 'space-between' : 'flex-end',
+          }}
+        >
+          {onAbort && <Button mode="outlined" onPress={onAbort}>Abort</Button>}
+          <Button mode="contained" onPress={onClose} disabled={!done}>
+            {done ? 'Close' : 'Wait'}
+          </Button>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+

--- a/app/UploadModal.tsx
+++ b/app/UploadModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { ScrollView, View } from 'react-native';
-import { Button, List, Modal, Portal, ProgressBar, RadioButton, Text } from 'react-native-paper';
+import { View } from 'react-native';
+import { Button, List, Modal, Portal, RadioButton, Text } from 'react-native-paper';
+import ProcessingModal from './ProcessingModal';
 
 export type UploadModalProps = {
   visible: boolean;
@@ -41,56 +42,48 @@ export default function UploadModal(props: UploadModalProps) {
 
   return (
     <Portal>
-      <Modal visible={visible} dismissable={false} contentContainerStyle={{ flex: 1, padding: 16, paddingTop: 64, backgroundColor: '#fff', height: '100%' }}>
-        <View style={{ flex: 1 }}>
-          {modalScreen === 'form' ? (
-            <>
-              <Text style={{ fontSize: 20, fontWeight: '700', marginBottom: 12 }}>Upload bank statement</Text>
-              <List.Section>
-                <List.Subheader>Bank</List.Subheader>
-                <RadioButton.Group onValueChange={(value) => setSelectedBank(value)} value={selectedBank ?? ''}>
-                  {banks.map((b) => (
-                    <RadioButton.Item key={b.id} label={b.label} value={b.id} />
-                  ))}
-                </RadioButton.Group>
-              </List.Section>
+      {modalScreen === 'form' ? (
+        <Modal
+          visible={visible}
+          dismissable={false}
+          contentContainerStyle={{ flex: 1, padding: 16, paddingTop: 64, backgroundColor: '#fff', height: '100%' }}
+        >
+          <View style={{ flex: 1 }}>
+            <Text style={{ fontSize: 20, fontWeight: '700', marginBottom: 12 }}>Upload bank statement</Text>
+            <List.Section>
+              <List.Subheader>Bank</List.Subheader>
+              <RadioButton.Group onValueChange={(value) => setSelectedBank(value)} value={selectedBank ?? ''}>
+                {banks.map((b) => (
+                  <RadioButton.Item key={b.id} label={b.label} value={b.id} />
+                ))}
+              </RadioButton.Group>
+            </List.Section>
 
-              <List.Section>
-                <List.Subheader>File</List.Subheader>
-                <Button mode="contained" icon="file-upload" onPress={onPickFile} style={{ marginBottom: 8 }} accessibilityLabel="Pick PDF file">
-                  Pick PDF file
-                </Button>
-                <Text style={{ fontSize: 12, color: 'gray', marginBottom: 8 }}>Only PDF files are allowed</Text>
-                {file && <Text style={{ marginVertical: 8 }}>{file.name}</Text>}
-              </List.Section>
+            <List.Section>
+              <List.Subheader>File</List.Subheader>
+              <Button mode="contained" icon="file-upload" onPress={onPickFile} style={{ marginBottom: 8 }} accessibilityLabel="Pick PDF file">
+                Pick PDF file
+              </Button>
+              <Text style={{ fontSize: 12, color: 'gray', marginBottom: 8 }}>Only PDF files are allowed</Text>
+              {file && <Text style={{ marginVertical: 8 }}>{file.name}</Text>}
+            </List.Section>
 
-              <View style={{ marginTop: 12, flexDirection: 'row', gap: 8 }}>
-                <Button mode="contained" onPress={onUpload} style={{ marginRight: 8 }}>Upload</Button>
-                <Button onPress={onCancelForm}>Cancel</Button>
-              </View>
-            </>
-          ) : (
-            <>
-              <Text style={{ fontSize: 20, fontWeight: '700', marginBottom: 12 }}>Processing statement</Text>
-              <Text style={{ marginBottom: 12, color: 'gray' }}>Processing can take between 1-2 minutes. The log below shows processing updates.</Text>
-              <View style={{ marginBottom: 12 }}>
-                <ProgressBar progress={processingStmtId ? (progress[processingStmtId] ?? 0) : 0} />
-              </View>
-
-              <View style={{ flex: 1, borderWidth: 1, borderColor: '#ddd', padding: 8, borderRadius: 6 }}>
-                <ScrollView>
-                  <Text selectable style={{ fontFamily: 'monospace', fontSize: 12 }}>{processingLog}</Text>
-                </ScrollView>
-              </View>
-
-              <View style={{ marginTop: 12, flexDirection: 'row', justifyContent: 'space-between' }}>
-                <Button mode="outlined" onPress={onAbort}>Abort</Button>
-                <Button mode="contained" onPress={onClose}>{processingCompleted ? 'Close' : 'Wait'}</Button>
-              </View>
-            </>
-          )}
-        </View>
-      </Modal>
+            <View style={{ marginTop: 12, flexDirection: 'row', gap: 8 }}>
+              <Button mode="contained" onPress={onUpload} style={{ marginRight: 8 }}>Upload</Button>
+              <Button onPress={onCancelForm}>Cancel</Button>
+            </View>
+          </View>
+        </Modal>
+      ) : (
+        <ProcessingModal
+          visible={visible}
+          log={processingLog}
+          progress={processingStmtId ? (progress[processingStmtId] ?? 0) : 0}
+          done={processingCompleted}
+          onClose={onClose}
+          onAbort={onAbort}
+        />
+      )}
     </Portal>
   );
 }

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -17,13 +17,13 @@ import {
   List,
   Modal,
   Portal,
-  ProgressBar,
   SegmentedButtons,
   Switch,
   Text,
   TextInput,
   useTheme,
 } from 'react-native-paper';
+import ProcessingModal from '../ProcessingModal';
 import {
   Entity,
   EntityCategory,
@@ -426,20 +426,20 @@ export default function StatementTransactions() {
         />
       )}
       <Portal>
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-          style={{ flex: 1 }}
+        <Modal
+          visible={promptModal}
+          onDismiss={() => setPromptModal(false)}
+          contentContainerStyle={{
+            backgroundColor: theme.colors.background,
+            padding: 12,
+            margin: 20,
+            borderRadius: 12,
+            maxHeight: height * 0.8,
+          }}
         >
-          <Modal
-            visible={promptModal}
-            onDismiss={() => setPromptModal(false)}
-            contentContainerStyle={{
-              backgroundColor: theme.colors.background,
-              padding: 12,
-              margin: 20,
-              borderRadius: 12,
-              height: 300,
-            }}
+          <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            style={{ flex: 1 }}
           >
             <Text style={{ marginBottom: 8 }}>Edit bank prompt</Text>
             <TextInput
@@ -463,20 +463,15 @@ export default function StatementTransactions() {
             >
               Save
             </Button>
-          </Modal>
-        </KeyboardAvoidingView>
-        <Modal
-          visible={processingVisible}
-          dismissable={false}
-          contentContainerStyle={{ backgroundColor: theme.colors.background, padding: 12, margin: 20, borderRadius: 12 }}
-        >
-          <Text style={{ marginBottom: 8 }}>Reprocessing</Text>
-          <ProgressBar progress={processingProgress} style={{ marginBottom: 8 }} />
-          <ScrollView style={{ maxHeight: 200, marginBottom: 8 }}>
-            <Text selectable style={{ fontFamily: 'monospace', fontSize: 12 }}>{processingLog}</Text>
-          </ScrollView>
-          <Button onPress={() => setProcessingVisible(false)} disabled={!processingDone}>Close</Button>
+          </KeyboardAvoidingView>
         </Modal>
+        <ProcessingModal
+          visible={processingVisible}
+          log={processingLog}
+          progress={processingProgress}
+          done={processingDone}
+          onClose={() => setProcessingVisible(false)}
+        />
         <Modal
           visible={!!editing}
           onDismiss={() => setEditing(null)}


### PR DESCRIPTION
## Summary
- Ensure bank prompt editor stays visible with keyboard
- Reuse processing modal for uploads and reprocessing
- Show saved prompt in learn log and disable wait until complete

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b6c3c8dc0883288a3273576c49bc03