### PR TITLE
feat: improve transaction modals

### DIFF
--- a/app/LearnModal.tsx
+++ b/app/LearnModal.tsx
@@ -99,7 +99,8 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
                 const checked = selected.has(t.id);
                 const isBankSender = t.senderId === bank.id;
                 const subjectLabel = isBankSender ? t.recipientLabel : t.senderLabel;
-                const signed = isBankSender ? `- ${nf.format(t.amount)}` : `+ ${nf.format(t.amount)}`;
+                const amt = t.shared ? t.sharedAmount ?? t.amount : t.amount;
+                const signed = isBankSender ? `- ${nf.format(amt)}` : `+ ${nf.format(amt)}`;
                 return (
                   <TouchableOpacity key={t.id} onPress={() => toggle(t.id)} style={{ flexDirection: 'row', alignItems: 'center', paddingVertical: 8 }}>
                     <Checkbox status={checked ? 'checked' : 'unchecked'} />
@@ -107,7 +108,10 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
                       <Text style={{ fontWeight: '700' }}>{subjectLabel || '-'}</Text>
                       <Text style={{ color: 'gray' }}>{t.description || '-'}</Text>
                     </View>
-                    <Text>{signed}</Text>
+                    <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+                      {t.shared && <Text style={{ marginRight: 6, color: 'gray' }}>(shared)</Text>}
+                      <Text>{signed}</Text>
+                    </View>
                   </TouchableOpacity>
                 );
               })}

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -308,6 +308,22 @@ export default function StatementTransactions() {
     setReviewedCount((c) => c + (reviewedAt ? 1 : -1));
   };
 
+  const markEditingReviewed = async () => {
+    if (!editing) return;
+    if (!editing.txn.reviewedAt) {
+      const updated = await updateTransaction(editing.txn.id, {
+        reviewedAt: Date.now(),
+      });
+      setTransactions((prev) =>
+        prev.map((t) =>
+          t.id === editing.txn.id ? { ...t, reviewedAt: updated.reviewedAt } : t
+        )
+      );
+      setReviewedCount((c) => c + 1);
+    }
+    setEditing(null);
+  };
+
   const openEntityPicker = (txnId: string, field: 'sender' | 'recipient') => {
     setPicker({ txnId, field });
   };
@@ -487,7 +503,7 @@ export default function StatementTransactions() {
             <View style={{ padding: 8 }}>
               <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
                 <Text style={{ fontSize: 18, fontWeight: '700' }}>Edit transaction</Text>
-                <Button onPress={() => setEditing(null)}>Dismiss</Button>
+                <Button onPress={markEditingReviewed}>Mark reviewed</Button>
               </View>
               <ScrollView>
                 <View style={{ marginTop: 12 }}>

--- a/lib/learn.ts
+++ b/lib/learn.ts
@@ -3,6 +3,8 @@ export type LearnTxn = {
   description: string | null;
   amount: number;
   shared: boolean;
+  /** Portion of the amount that is shared, if applicable */
+  sharedAmount?: number | null;
   senderId: string | null;
   recipientId: string | null;
   senderLabel: string;


### PR DESCRIPTION
## Summary
- mark transactions as reviewed from edit modal
- show shared amounts in learn mode list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c56ec33c8328bd02897e4a5b4374