### PR TITLE
feat: dedicated bank prompt screen and learn prompt update

### DIFF
--- a/app/bank-prompt.tsx
+++ b/app/bank-prompt.tsx
@@ -1,0 +1,54 @@
+import { useLocalSearchParams, router } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { View } from 'react-native';
+import { Button, Text, TextInput } from 'react-native-paper';
+import { getEntity, updateBankAccount } from '../lib/entities';
+
+export default function EditBankPrompt() {
+  const { bankId } = useLocalSearchParams<{ bankId: string }>();
+  const [label, setLabel] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [currency, setCurrency] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      if (!bankId) return;
+      const bank = await getEntity(bankId);
+      if (bank) {
+        setLabel(bank.label);
+        setPrompt(bank.prompt ?? '');
+        setCurrency(bank.currency);
+      }
+    })();
+  }, [bankId]);
+
+  const save = async () => {
+    if (!bankId) return;
+    await updateBankAccount(bankId, { label, prompt, currency });
+    router.back();
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text style={{ marginBottom: 4 }}>Bank</Text>
+      <TextInput mode="outlined" value={label} editable={false} style={{ marginBottom: 12 }} />
+      <Text style={{ marginBottom: 4 }}>Prompt</Text>
+      <TextInput
+        mode="outlined"
+        multiline
+        value={prompt}
+        onChangeText={setPrompt}
+        style={{ marginBottom: 12, height: 128 }}
+      />
+      <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
+        <Button onPress={() => router.back()} style={{ marginRight: 8 }}>
+          Cancel
+        </Button>
+        <Button mode="contained" onPress={save}>
+          Save
+        </Button>
+      </View>
+    </View>
+  );
+}
+

--- a/lib/openai.ts
+++ b/lib/openai.ts
@@ -45,7 +45,7 @@ export const DEFAULT_SYSTEM_PROMPT = `You are a precise financial data parser. E
 
 export const LEARN_PROMPT_STORAGE_KEY = 'learn_prompt';
 export const DEFAULT_LEARN_PROMPT =
-  'Concise and without any formatting. update the following prompt for a bank transaction parsing service so that the following mappings are learned as the golden data.';
+  'Append the following transactions such that it represents a golden data set. No formatting just list them out with classifications to have some specific examples. Drop the transaction number. Dedupe if there are the same entries. prefix the examples with: these are golden set examples that are correctly classified';
 
 async function uploadFile(apiKey: string, file: any, signal?: AbortSignal, onLog?: (m: string) => void): Promise<string> {
   // Use the installed OpenAI SDK (imported at module top). If the provided


### PR DESCRIPTION
## Summary
- set new default learn prompt text
- replace bank prompt modal with dedicated screen
- refresh statement view after editing bank prompt

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c715c34c83289637630510758dc7