### PR TITLE
Improve statement transaction UI and navigation icons

### DIFF
--- a/app/ProcessingModal.tsx
+++ b/app/ProcessingModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { ScrollView, View } from 'react-native';
 import { Button, Modal, ProgressBar, Text, useTheme } from 'react-native-paper';
 
@@ -22,6 +22,10 @@ export default function ProcessingModal({
   onAbort,
 }: ProcessingModalProps) {
   const theme = useTheme();
+  const scrollRef = useRef<ScrollView>(null);
+  useEffect(() => {
+    scrollRef.current?.scrollToEnd({ animated: true });
+  }, [log]);
   return (
     <Modal
       visible={visible}
@@ -43,7 +47,7 @@ export default function ProcessingModal({
           <ProgressBar progress={progress} />
         </View>
         <View style={{ flex: 1, borderWidth: 1, borderColor: '#ddd', padding: 8, borderRadius: 6 }}>
-          <ScrollView>
+          <ScrollView ref={scrollRef}>
             <Text selectable style={{ fontFamily: 'monospace', fontSize: 12 }}>
               {log}
             </Text>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -100,9 +100,24 @@ export default function Index() {
   const router = useRouter();
   const [navIndex, setNavIndex] = useState(0);
   const [navRoutes] = useState([
-    { key: 'import', title: 'Import', icon: 'file-import' },
-    { key: 'analysis', title: 'Analysis', icon: 'chart-bar' },
-    { key: 'settings', title: 'Settings', icon: 'cog' },
+    {
+      key: 'import',
+      title: 'Import',
+      focusedIcon: 'file-import',
+      unfocusedIcon: 'file-import-outline',
+    },
+    {
+      key: 'analysis',
+      title: 'Analysis',
+      focusedIcon: 'chart-bar',
+      unfocusedIcon: 'chart-bar',
+    },
+    {
+      key: 'settings',
+      title: 'Settings',
+      focusedIcon: 'cog',
+      unfocusedIcon: 'cog-outline',
+    },
   ]);
   const [statements, setStatements] = useState<StatementMeta[]>([]);
   const [banks, setBanks] = useState<Entity[]>([]);


### PR DESCRIPTION
## Summary
- Show live processing logs with auto-scrolling and logging callbacks
- Add category prefixes and prompt editing bottom sheet in statement view
- Display icons in bottom navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f7a8eee48328b1b249a2399a72c3