### PR TITLE
Fix statement transactions modal import

### DIFF
--- a/app/LearnModal.tsx
+++ b/app/LearnModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ScrollView, View, TouchableOpacity } from 'react-native';
 import { Button, Checkbox, Modal, Portal, ProgressBar, Text } from 'react-native-paper';
+import { Currency } from '../lib/currencies';
 import * as SecureStore from 'expo-secure-store';
 import {
   OPENAI_KEY_STORAGE_KEY,
@@ -13,7 +14,7 @@ import { LearnTxn, prepareLearningTransactions } from '../lib/learn';
 
 export type LearnModalProps = {
   visible: boolean;
-  bank: { id: string; prompt: string; label: string; currency: string };
+  bank: { id: string; prompt: string; label: string; currency: Currency };
   transactions: LearnTxn[];
   onDismiss: () => void;
   onComplete: (prompt: string) => void;

--- a/app/bank-prompt.tsx
+++ b/app/bank-prompt.tsx
@@ -3,12 +3,13 @@ import { useEffect, useState } from 'react';
 import { View } from 'react-native';
 import { Button, Text, TextInput } from 'react-native-paper';
 import { getEntity, updateBankAccount } from '../lib/entities';
+import { Currency } from '../lib/currencies';
 
 export default function EditBankPrompt() {
   const { bankId } = useLocalSearchParams<{ bankId: string }>();
   const [label, setLabel] = useState('');
   const [prompt, setPrompt] = useState('');
-  const [currency, setCurrency] = useState('');
+  const [currency, setCurrency] = useState<Currency>('USD');
 
   useEffect(() => {
     (async () => {

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -12,7 +12,6 @@ import {
 } from 'react-native';
 import {
   AnimatedFAB,
-  BottomSheetModal,
   Button,
   Card,
   Checkbox,
@@ -34,6 +33,7 @@ import {
   listEntities,
   updateBankAccount,
 } from '../../lib/entities';
+import { Currency } from '../../lib/currencies';
 import { getStatement, reprocessStatement } from '../../lib/statements';
 import {
   listTransactions,
@@ -72,7 +72,7 @@ export default function StatementTransactions() {
     bank: string;
     bankId: string;
     bankPrompt: string;
-    currency: string;
+    currency: Currency;
     count: number;
     externalFileId: string | null;
   } | null>(null);
@@ -244,7 +244,7 @@ export default function StatementTransactions() {
           bank: bank?.label ?? '',
           bankId: stmt.bankId,
           bankPrompt: bank?.prompt ?? '',
-          currency: bank?.currency ?? '',
+          currency: bank?.currency ?? 'USD',
           count: list.length,
           externalFileId: stmt.externalFileId ?? null,
         });
@@ -641,30 +641,37 @@ export default function StatementTransactions() {
             )}
           </ScrollView>
         </Modal>
-        <BottomSheetModal visible={promptVisible} onDismiss={() => setPromptVisible(false)}>
+        <Modal
+          visible={promptVisible}
+          onDismiss={() => setPromptVisible(false)}
+          contentContainerStyle={{
+            backgroundColor: theme.colors.background,
+            padding: 16,
+            margin: 20,
+            borderRadius: 12,
+          }}
+        >
           <KeyboardAvoidingView
             behavior={Platform.OS === 'ios' ? 'padding' : undefined}
             style={{ flex: 1 }}
           >
-            <View style={{ padding: 16 }}>
-              <TextInput
-                mode="outlined"
-                multiline
-                value={promptText}
-                onChangeText={setPromptText}
-                style={{ height: 128, marginBottom: 12 }}
-              />
-              <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
-                <Button onPress={() => setPromptVisible(false)} style={{ marginRight: 8 }}>
-                  Cancel
-                </Button>
-                <Button mode="contained" onPress={saveBankPrompt}>
-                  Save
-                </Button>
-              </View>
+            <TextInput
+              mode="outlined"
+              multiline
+              value={promptText}
+              onChangeText={setPromptText}
+              style={{ height: 128, marginBottom: 12 }}
+            />
+            <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
+              <Button onPress={() => setPromptVisible(false)} style={{ marginRight: 8 }}>
+                Cancel
+              </Button>
+              <Button mode="contained" onPress={saveBankPrompt}>
+                Save
+              </Button>
             </View>
           </KeyboardAvoidingView>
-        </BottomSheetModal>
+        </Modal>
         {!processingVisible && !editing && !picker && !promptVisible && !fabOpen && (
           <AnimatedFAB
             icon="menu"


### PR DESCRIPTION
## Summary
- replace unsupported BottomSheetModal with Modal on statement transactions page
- type bank currency values to satisfy TS checks

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b703aa58008328b4098cfc4afc137a