### PR TITLE
Move bank prompt editing to dedicated page

### DIFF
--- a/__tests__/entities.test.ts
+++ b/__tests__/entities.test.ts
@@ -57,6 +57,11 @@ test('create, update, delete bank account', async () => {
   expect(list.length).toBe(0);
 });
 
+test('create bank account without prompt', async () => {
+  const created = await createBankAccount({ label: 'NoPrompt', currency: 'USD' });
+  expect(created.prompt).toBe('');
+});
+
 test('create and delete income category', async () => {
   const item = await createEntity({
     label: 'Bonus',

--- a/app/bank-accounts/form.tsx
+++ b/app/bank-accounts/form.tsx
@@ -23,7 +23,7 @@ export default function BankAccountForm({ initial, onSubmit, submitLabel }: Prop
   const handleSave = async () => {
     const input: BankAccountInput = {
       label: label.trim(),
-      prompt: prompt.trim(),
+      prompt: prompt.trim() || undefined,
       currency: currency as any,
     };
     const result = bankAccountSchema.safeParse(input);
@@ -52,8 +52,12 @@ export default function BankAccountForm({ initial, onSubmit, submitLabel }: Prop
           value={prompt}
           onChangeText={setPrompt}
           multiline
-          style={{ marginBottom: 12, height: 128 }}
+          style={{ marginBottom: 4, height: 128 }}
         />
+        <Text style={{ marginBottom: 12, color: theme.colors.onSurfaceVariant }}>
+          List specifics that are important to consider for the processing of the
+          file.
+        </Text>
         <Text style={{ marginBottom: 4 }}>Currency</Text>
         <Menu
           visible={menuVisible}

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -1,10 +1,8 @@
-import { useLocalSearchParams, useNavigation } from 'expo-router';
+import { useLocalSearchParams, useNavigation, router } from 'expo-router';
 import { useCallback, useEffect, useState, useMemo } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
 import {
   Alert,
-  KeyboardAvoidingView,
-  Platform,
   ScrollView,
   TouchableOpacity,
   useWindowDimensions,
@@ -26,13 +24,7 @@ import {
   useTheme,
 } from 'react-native-paper';
 import ProcessingModal from '../ProcessingModal';
-import {
-  Entity,
-  EntityCategory,
-  getEntity,
-  listEntities,
-  updateBankAccount,
-} from '../../lib/entities';
+import { Entity, EntityCategory, getEntity, listEntities } from '../../lib/entities';
 import { Currency } from '../../lib/currencies';
 import { getStatement, reprocessStatement } from '../../lib/statements';
 import {
@@ -86,8 +78,6 @@ export default function StatementTransactions() {
   const [processingProgress, setProcessingProgress] = useState(0);
   const [processingLog, setProcessingLog] = useState('');
   const [processingDone, setProcessingDone] = useState(false);
-  const [promptVisible, setPromptVisible] = useState(false);
-  const [promptText, setPromptText] = useState('');
   const { width, height } = useWindowDimensions();
   const isLandscape = width > height;
   const theme = useTheme();
@@ -132,19 +122,7 @@ export default function StatementTransactions() {
 
   const openBankPrompt = () => {
     if (!meta) return;
-    setPromptText(meta.bankPrompt);
-    setPromptVisible(true);
-  };
-
-  const saveBankPrompt = async () => {
-    if (!meta) return;
-    await updateBankAccount(meta.bankId, {
-      label: meta.bank,
-      prompt: promptText,
-      currency: meta.currency,
-    });
-    setMeta((m) => (m ? { ...m, bankPrompt: promptText } : m));
-    setPromptVisible(false);
+    router.push({ pathname: '/bank-prompt', params: { bankId: meta.bankId } });
   };
 
   const handleReprocess = () => {
@@ -641,47 +619,14 @@ export default function StatementTransactions() {
             )}
           </ScrollView>
         </Modal>
-        <Modal
-          visible={promptVisible}
-          onDismiss={() => setPromptVisible(false)}
-          contentContainerStyle={{
-            backgroundColor: theme.colors.background,
-            padding: 16,
-            margin: 20,
-            borderRadius: 12,
-          }}
-        >
-          <KeyboardAvoidingView
-            behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-            style={{ flex: 1 }}
-          >
-            <TextInput
-              mode="outlined"
-              multiline
-              value={promptText}
-              onChangeText={setPromptText}
-              style={{ height: 128, marginBottom: 12 }}
-            />
-            <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
-              <Button onPress={() => setPromptVisible(false)} style={{ marginRight: 8 }}>
-                Cancel
-              </Button>
-              <Button mode="contained" onPress={saveBankPrompt}>
-                Save
-              </Button>
-            </View>
-          </KeyboardAvoidingView>
-        </Modal>
-        {!processingVisible && !editing && !picker && !promptVisible && !fabOpen && (
+        {!processingVisible && !editing && !picker && !fabOpen && (
           <AnimatedFAB
             icon="menu"
-            label="Train classification and more"
-            extended
             onPress={() => setFabOpen(true)}
             style={{ position: 'absolute', right: 16, bottom: 16 }}
           />
         )}
-        {!processingVisible && !editing && !picker && !promptVisible && fabOpen && (
+        {!processingVisible && !editing && !picker && fabOpen && (
           <FAB.Group
             visible={fabOpen}
             open={fabOpen}

--- a/lib/entities.ts
+++ b/lib/entities.ts
@@ -21,24 +21,24 @@ export type ExpenseCategory = Entity;
 export const entitySchema = z.object({
   label: z.string().min(1, 'Label is required'),
   category: z.enum(['bank', 'expense', 'income', 'savings']),
-  prompt: z.string().min(1, 'Prompt is required'),
+  prompt: z.string().optional().default(''),
   parentId: z.string().nullable().optional(),
   currency: z.enum(SUPPORTED_CURRENCIES),
 });
 
 export type EntityInput = z.infer<typeof entitySchema>;
 
-export const bankAccountSchema = entitySchema.pick({
-  label: true,
-  prompt: true,
-  currency: true,
+export const bankAccountSchema = z.object({
+  label: z.string().min(1, 'Label is required'),
+  prompt: z.string().optional(),
+  currency: z.enum(SUPPORTED_CURRENCIES),
 });
 export type BankAccountInput = z.infer<typeof bankAccountSchema>;
 
-export const expenseCategorySchema = entitySchema.pick({
-  label: true,
-  prompt: true,
-  parentId: true,
+export const expenseCategorySchema = z.object({
+  label: z.string().min(1, 'Label is required'),
+  prompt: z.string().min(1, 'Prompt is required'),
+  parentId: z.string().nullable().optional(),
 });
 export type ExpenseCategoryInput = z.infer<typeof expenseCategorySchema>;
 
@@ -140,12 +140,22 @@ export async function getBankAccount(id: string) {
 
 export async function createBankAccount(input: BankAccountInput) {
   const parsed = bankAccountSchema.parse(input);
-  return createEntity({ ...parsed, category: 'bank', parentId: null });
+  return createEntity({
+    ...parsed,
+    prompt: parsed.prompt ?? '',
+    category: 'bank',
+    parentId: null,
+  });
 }
 
 export async function updateBankAccount(id: string, input: BankAccountInput) {
   const parsed = bankAccountSchema.parse(input);
-  return updateEntity(id, { ...parsed, category: 'bank', parentId: null });
+  return updateEntity(id, {
+    ...parsed,
+    prompt: parsed.prompt ?? '',
+    category: 'bank',
+    parentId: null,
+  });
 }
 
 export async function deleteBankAccount(id: string) {


### PR DESCRIPTION
## Summary
- navigate to a standalone bank prompt editor instead of modal
- make bank prompts optional with helper copy when adding banks
- remove AnimatedFAB label on statement view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b70b1b3cd483288e0c25096fa4a10b