### PR TITLE
feat: add key metrics to analysis

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -1,9 +1,9 @@
 jest.mock('expo-sqlite', () => require('../test-utils/sqliteMock').sqliteMock);
 
 import { createStatement } from '../lib/statements';
-import { createExpenseCategory } from '../lib/entities';
+import { createExpenseCategory, createEntity } from '../lib/entities';
 import { createTransaction } from '../lib/transactions';
-import { summarizeExpensesByParent } from '../lib/analytics';
+import { summarizeExpensesByParent, computeKeyMetrics } from '../lib/analytics';
 import sqliteMock from '../test-utils/sqliteMock';
 
 describe('analytics', () => {
@@ -28,5 +28,91 @@ describe('analytics', () => {
       { parentId: food.id, parentLabel: 'Food', total: 100 },
       { parentId: transport.id, parentLabel: 'Transport', total: 75 },
     ]);
+  });
+
+  it('computes key metrics', async () => {
+    const salary = await createEntity({
+      label: 'Salary',
+      category: 'income',
+      prompt: 'Salary',
+      parentId: null,
+      currency: 'USD',
+    });
+    const save = await createEntity({
+      label: 'Save',
+      category: 'savings',
+      prompt: 'Save',
+      parentId: null,
+      currency: 'USD',
+    });
+    const food = await createExpenseCategory({
+      label: 'Food',
+      prompt: 'Food',
+      parentId: null,
+    });
+    const stmt = await createStatement({ bankId: '1', uploadDate: 1, status: 'new' });
+    const now = Date.now();
+    await createTransaction({
+      statementId: stmt.id,
+      senderId: salary.id,
+      recipientId: null,
+      createdAt: now - 1000,
+      amount: 100,
+      currency: 'USD',
+      shared: false,
+    });
+    await createTransaction({
+      statementId: stmt.id,
+      recipientId: food.id,
+      senderId: null,
+      createdAt: now - 900,
+      amount: 30,
+      currency: 'USD',
+      shared: false,
+    });
+    await createTransaction({
+      statementId: stmt.id,
+      recipientId: save.id,
+      senderId: null,
+      createdAt: now - 800,
+      amount: 20,
+      currency: 'USD',
+      shared: false,
+    });
+    await createTransaction({
+      statementId: stmt.id,
+      recipientId: null,
+      senderId: save.id,
+      createdAt: now - 700,
+      amount: 5,
+      currency: 'USD',
+      shared: false,
+    });
+
+    const res = await computeKeyMetrics(now - 2000, now, [salary.id], [save.id]);
+    expect(res).toEqual({ income: 100, expenses: 30, savings: 15, cashflow: 70 });
+  });
+
+  it('returns zeros when no matching entities', async () => {
+    const stmt = await createStatement({ bankId: '1', uploadDate: 1, status: 'new' });
+    const now = Date.now();
+    const salary = await createEntity({
+      label: 'Salary',
+      category: 'income',
+      prompt: 'Salary',
+      parentId: null,
+      currency: 'USD',
+    });
+    await createTransaction({
+      statementId: stmt.id,
+      senderId: salary.id,
+      recipientId: null,
+      createdAt: now - 1000,
+      amount: 100,
+      currency: 'USD',
+      shared: false,
+    });
+    const res = await computeKeyMetrics(now - 2000, now, [], []);
+    expect(res).toEqual({ income: 0, expenses: 0, savings: 0, cashflow: 0 });
   });
 });

--- a/app/analysis.tsx
+++ b/app/analysis.tsx
@@ -1,10 +1,106 @@
 import { useEffect, useState } from 'react';
-import { View } from 'react-native';
-import { SegmentedButtons, Text } from 'react-native-paper';
+import { View, ScrollView, TouchableOpacity } from 'react-native';
+import {
+  SegmentedButtons,
+  Text,
+  Card,
+  Modal,
+  Portal,
+  Button,
+  Chip,
+  List,
+  useTheme,
+} from 'react-native-paper';
 import Svg, { Rect, Text as SvgText } from 'react-native-svg';
-import { summarizeExpensesByParent, ExpenseSummary } from '../lib/analytics';
+import {
+  summarizeExpensesByParent,
+  ExpenseSummary,
+  computeKeyMetrics,
+  KeyMetrics,
+} from '../lib/analytics';
+import { listEntities, Entity } from '../lib/entities';
 
 type RangeKey = '7d' | '1m' | 'qtd' | 'ytd';
+
+interface MetricModalProps {
+  visible: boolean;
+  title: string;
+  entities: Entity[];
+  selected: string[];
+  onSave: (ids: string[]) => void;
+  onDismiss: () => void;
+}
+
+function MetricModal({
+  visible,
+  title,
+  entities,
+  selected,
+  onSave,
+  onDismiss,
+}: MetricModalProps) {
+  const [current, setCurrent] = useState<string[]>(selected);
+  const theme = useTheme();
+
+  useEffect(() => {
+    setCurrent(selected);
+  }, [selected, visible]);
+
+  const toggle = (id: string) => {
+    setCurrent((prev) =>
+      prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]
+    );
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      onDismiss={onDismiss}
+      contentContainerStyle={{ margin: 20, flex: 1 }}
+    >
+      <View
+        style={{
+          backgroundColor: theme.colors.background,
+          flex: 1,
+          borderRadius: 12,
+        }}
+      >
+        <View style={{ padding: 16 }}>
+          <Text variant="headlineMedium">{title}</Text>
+          <Text>Entities that sum to the metric</Text>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginTop: 8 }}>
+            {current.map((id) => {
+              const ent = entities.find((e) => e.id === id);
+              if (!ent) return null;
+              return (
+                <Chip key={id} onPress={() => toggle(id)} style={{ margin: 4 }}>
+                  {ent.label}
+                </Chip>
+              );
+            })}
+          </View>
+        </View>
+        <Text style={{ marginHorizontal: 16, marginTop: 8, fontWeight: 'bold' }}>
+          Select entities for metric
+        </Text>
+        <ScrollView style={{ flex: 1, marginTop: 8 }}>
+          {entities.map((ent) => (
+            <List.Item
+              key={ent.id}
+              title={ent.label}
+              onPress={() => toggle(ent.id)}
+            />
+          ))}
+        </ScrollView>
+        <View style={{ padding: 16 }}>
+          <Button mode="contained" onPress={() => onSave(current)}>
+            Save
+          </Button>
+        </View>
+      </View>
+    </Modal>
+  );
+}
 
 function getRange(key: RangeKey): { start: number; end: number } {
   const now = new Date();
@@ -31,6 +127,17 @@ function getRange(key: RangeKey): { start: number; end: number } {
 export default function Analysis() {
   const [range, setRange] = useState<RangeKey>('ytd');
   const [data, setData] = useState<ExpenseSummary[]>([]);
+  const [metrics, setMetrics] = useState<KeyMetrics>({
+    income: 0,
+    expenses: 0,
+    savings: 0,
+    cashflow: 0,
+  });
+  const [incomeEntities, setIncomeEntities] = useState<Entity[]>([]);
+  const [savingsEntities, setSavingsEntities] = useState<Entity[]>([]);
+  const [selectedIncome, setSelectedIncome] = useState<string[]>([]);
+  const [selectedSavings, setSelectedSavings] = useState<string[]>([]);
+  const [modal, setModal] = useState<'income' | 'savings' | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -40,14 +147,64 @@ export default function Analysis() {
     })();
   }, [range]);
 
+  useEffect(() => {
+    (async () => {
+      const [inc, sav] = await Promise.all([
+        listEntities('income'),
+        listEntities('savings'),
+      ]);
+      setIncomeEntities(inc);
+      setSavingsEntities(sav);
+      setSelectedIncome(inc.map((e) => e.id));
+      setSelectedSavings(sav.map((e) => e.id));
+    })();
+  }, []);
+
+  useEffect(() => {
+    (async () => {
+      const { start, end } = getRange(range);
+      const res = await computeKeyMetrics(start, end, selectedIncome, selectedSavings);
+      setMetrics(res);
+    })();
+  }, [range, selectedIncome, selectedSavings]);
+
   const max = data.reduce((m, d) => Math.max(m, d.total), 0);
   const barWidth = 40;
   const gap = 20;
   const chartHeight = 180;
+  const nf = new Intl.NumberFormat(undefined, { style: 'currency', currency: 'USD' });
 
   return (
     <View style={{ flex: 1, padding: 16 }}>
-      <View style={{ height: chartHeight + 20 }}>
+      <Card>
+        <Card.Content>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+            <View style={{ width: '50%', marginBottom: 12 }}>
+              <Text variant="headlineMedium">Cashflow</Text>
+              <Text>{nf.format(metrics.cashflow)}</Text>
+            </View>
+            <TouchableOpacity
+              style={{ width: '50%', marginBottom: 12 }}
+              onPress={() => setModal('income')}
+            >
+              <Text variant="headlineMedium">Income</Text>
+              <Text>{nf.format(metrics.income)}</Text>
+            </TouchableOpacity>
+            <View style={{ width: '50%', marginBottom: 12 }}>
+              <Text variant="headlineMedium">Expenses</Text>
+              <Text>{nf.format(metrics.expenses)}</Text>
+            </View>
+            <TouchableOpacity
+              style={{ width: '50%', marginBottom: 12 }}
+              onPress={() => setModal('savings')}
+            >
+              <Text variant="headlineMedium">Savings</Text>
+              <Text>{nf.format(metrics.savings)}</Text>
+            </TouchableOpacity>
+          </View>
+        </Card.Content>
+      </Card>
+      <View style={{ height: chartHeight + 20, marginTop: 16 }}>
         {data.length === 0 ? (
           <Text>No data</Text>
         ) : (
@@ -92,6 +249,30 @@ export default function Analysis() {
         ]}
         style={{ marginTop: 16 }}
       />
+      <Portal>
+        <MetricModal
+          visible={modal === 'income'}
+          title="Define income"
+          entities={incomeEntities}
+          selected={selectedIncome}
+          onSave={(ids) => {
+            setSelectedIncome(ids);
+            setModal(null);
+          }}
+          onDismiss={() => setModal(null)}
+        />
+        <MetricModal
+          visible={modal === 'savings'}
+          title="Define savings"
+          entities={savingsEntities}
+          selected={selectedSavings}
+          onSave={(ids) => {
+            setSelectedSavings(ids);
+            setModal(null);
+          }}
+          onDismiss={() => setModal(null)}
+        />
+      </Portal>
     </View>
   );
 }


### PR DESCRIPTION
## Summary
- add analytics helpers for income, expense, savings and cashflow
- show key metrics card on analysis screen with custom income/savings selections
- test key metrics calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b81e4fb8a88328bdf07bdc7bec7554