### PR TITLE
fix: show metric modal on analytics

### DIFF
--- a/app/analysis.tsx
+++ b/app/analysis.tsx
@@ -250,28 +250,30 @@ export default function Analysis() {
         style={{ marginTop: 16 }}
       />
       <Portal>
-        <MetricModal
-          visible={modal === 'income'}
-          title="Define income"
-          entities={incomeEntities}
-          selected={selectedIncome}
-          onSave={(ids) => {
-            setSelectedIncome(ids);
-            setModal(null);
-          }}
-          onDismiss={() => setModal(null)}
-        />
-        <MetricModal
-          visible={modal === 'savings'}
-          title="Define savings"
-          entities={savingsEntities}
-          selected={selectedSavings}
-          onSave={(ids) => {
-            setSelectedSavings(ids);
-            setModal(null);
-          }}
-          onDismiss={() => setModal(null)}
-        />
+        <>
+          <MetricModal
+            visible={modal === 'income'}
+            title="Define income"
+            entities={incomeEntities}
+            selected={selectedIncome}
+            onSave={(ids) => {
+              setSelectedIncome(ids);
+              setModal(null);
+            }}
+            onDismiss={() => setModal(null)}
+          />
+          <MetricModal
+            visible={modal === 'savings'}
+            title="Define savings"
+            entities={savingsEntities}
+            selected={selectedSavings}
+            onSave={(ids) => {
+              setSelectedSavings(ids);
+              setModal(null);
+            }}
+            onDismiss={() => setModal(null)}
+          />
+        </>
       </Portal>
     </View>
   );


### PR DESCRIPTION
## Summary
- ensure metric definition modals render on analytics page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8448523d083288ce725f0bde23633