### PR TITLE
feat: add split credit metric to analytics

### DIFF
--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -92,14 +92,26 @@ describe('analytics', () => {
       shared: false,
       reviewedAt: now - 700,
     });
+    await createTransaction({
+      statementId: stmt.id,
+      recipientId: food.id,
+      senderId: null,
+      createdAt: now - 600,
+      amount: 40,
+      currency: 'USD',
+      shared: true,
+      sharedAmount: 10,
+      reviewedAt: now - 600,
+    });
 
     const res = await computeKeyMetrics(now - 2000, now, [salary.id], [save.id]);
     expect(res).toEqual({
       income: 100,
-      expenses: 30,
+      expenses: 70,
       savings: 15,
-      cashflow: 70,
+      cashflow: 30,
       savingsRatio: 0.15,
+      splitCredit: 30,
     });
   });
 
@@ -130,6 +142,7 @@ describe('analytics', () => {
       savings: 0,
       cashflow: 0,
       savingsRatio: 0,
+      splitCredit: 0,
     });
   });
 
@@ -176,6 +189,16 @@ describe('analytics', () => {
     });
     await createTransaction({
       statementId: stmt.id,
+      recipientId: food.id,
+      senderId: null,
+      createdAt: now - 850,
+      amount: 40,
+      currency: 'USD',
+      shared: true,
+      sharedAmount: 15,
+    });
+    await createTransaction({
+      statementId: stmt.id,
       recipientId: save.id,
       senderId: null,
       createdAt: now - 800,
@@ -191,6 +214,7 @@ describe('analytics', () => {
       savings: 0,
       cashflow: 100,
       savingsRatio: 0,
+      splitCredit: 0,
     });
   });
 });

--- a/app/analysis.tsx
+++ b/app/analysis.tsx
@@ -4,6 +4,7 @@ import {
   SegmentedButtons,
   Text,
   Card,
+  Tooltip,
 } from 'react-native-paper';
 import Svg, { Rect, Text as SvgText } from 'react-native-svg';
 import {
@@ -55,6 +56,7 @@ export default function Analysis() {
     savings: 0,
     cashflow: 0,
     savingsRatio: 0,
+    splitCredit: 0,
   });
   const [selectedIncome, setSelectedIncome] = useState<string[]>([]);
   const [selectedSavings, setSelectedSavings] = useState<string[]>([]);
@@ -134,6 +136,12 @@ export default function Analysis() {
             <View style={{ width: '50%', marginBottom: 12 }}>
               <Text variant="headlineMedium">Expenses</Text>
               <Text>{nf.format(metrics.expenses)}</Text>
+            </View>
+            <View style={{ width: '50%', marginBottom: 12 }}>
+              <Tooltip title="Total amount minus shared amounts of shared, reviewed transactions in this timeframe">
+                <Text variant="headlineMedium">Split Credit</Text>
+              </Tooltip>
+              <Text>{nf.format(metrics.splitCredit)}</Text>
             </View>
             <TouchableOpacity
               style={{ width: '50%', marginBottom: 12 }}


### PR DESCRIPTION
## Summary
- compute split credit across shared reviewed transactions
- display Split Credit key metric with explanatory tooltip on analytics screen
- test split credit calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b855fa6a908328a9b770870d79d07b