### PR TITLE
Format entity keys in CSV export

### DIFF
--- a/__tests__/analytics-export.test.ts
+++ b/__tests__/analytics-export.test.ts
@@ -13,8 +13,16 @@ describe('exportReviewedTransactionsToCsv', () => {
   });
 
   it('exports reviewed transactions with entity keys', async () => {
-    const parent = await createExpenseCategory({ label: 'Food', prompt: 'Food', parentId: null });
-    const child = await createExpenseCategory({ label: 'Groceries', prompt: 'Groceries', parentId: parent.id });
+    const parent = await createExpenseCategory({
+      label: 'Food and Drink',
+      prompt: 'Food and Drink',
+      parentId: null,
+    });
+    const child = await createExpenseCategory({
+      label: 'Groceries Store',
+      prompt: 'Groceries Store',
+      parentId: parent.id,
+    });
     const income = await createEntity({
       label: 'Salary',
       category: 'income',
@@ -51,7 +59,7 @@ describe('exportReviewedTransactionsToCsv', () => {
     expect(lines).toHaveLength(2);
     const row = lines[1].split(',');
     expect(row[3]).toBe('100');
-    expect(row[4]).toBe('incomeSalary');
-    expect(row[5]).toBe('expenseFoodGroceries');
+    expect(row[4]).toBe('income_salary');
+    expect(row[5]).toBe('expense_foodAndDrink_groceriesStore');
   });
 });

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -217,7 +217,8 @@ function buildEntityKey(
     if (!current.parentId) break;
     current = map.get(current.parentId) || null;
   }
-  return toCamel([entity.category, ...labels]);
+  const tokens = [entity.category, ...labels].map((l) => toCamel([l]));
+  return tokens.join('_');
 }
 
 function escapeCsv(val: string): string {


### PR DESCRIPTION
## Summary
- format entity keys in analytics CSV export using camelCase tokens joined by underscores
- adjust analytics export test for new key style

## Testing
- `npm test __tests__/analytics-export.test.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa38abd1083288b129ce06ebac9a2