### PR TITLE
feat: add time scope picker

### DIFF
--- a/__tests__/timeScope.test.ts
+++ b/__tests__/timeScope.test.ts
@@ -1,0 +1,46 @@
+import { scopeToRange, Scope } from '../lib/timeScope';
+
+describe('scopeToRange', () => {
+  it('handles month scope', () => {
+    const scope: Scope = { mode: 'month', year: 2025, month: 8 };
+    const { start, end } = scopeToRange(scope);
+    expect(start).toBe(new Date(2025, 7, 1).getTime());
+    expect(end).toBe(new Date(2025, 8, 1).getTime());
+  });
+
+  it('handles year scope', () => {
+    const scope: Scope = { mode: 'year', year: 2024 };
+    const { start, end } = scopeToRange(scope);
+    expect(start).toBe(new Date(2024, 0, 1).getTime());
+    expect(end).toBe(new Date(2025, 0, 1).getTime());
+  });
+
+  it('handles all scope', () => {
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(123456);
+    const scope: Scope = { mode: 'all' };
+    const { start, end } = scopeToRange(scope);
+    expect(start).toBe(0);
+    expect(end).toBe(123456);
+    spy.mockRestore();
+  });
+
+  it('handles custom scope', () => {
+    const scope: Scope = {
+      mode: 'custom',
+      startISO: '2024-01-01T00:00:00.000Z',
+      endISO: '2024-01-31T00:00:00.000Z',
+    };
+    const { start, end } = scopeToRange(scope);
+    expect(start).toBe(new Date('2024-01-01T00:00:00.000Z').getTime());
+    expect(end).toBe(new Date('2024-01-31T00:00:00.000Z').getTime());
+  });
+
+  it('throws on invalid custom scope', () => {
+    const scope: Scope = {
+      mode: 'custom',
+      startISO: '2024-02-01T00:00:00.000Z',
+      endISO: '2024-01-31T00:00:00.000Z',
+    };
+    expect(() => scopeToRange(scope)).toThrow('start must be before end');
+  });
+});

--- a/app/TimeScopePicker.tsx
+++ b/app/TimeScopePicker.tsx
@@ -1,0 +1,149 @@
+import { useState } from 'react';
+import {
+  View,
+  ScrollView,
+  TextInput,
+} from 'react-native';
+import {
+  Button,
+  Modal,
+  Portal,
+  SegmentedButtons,
+  Text,
+  IconButton,
+  List,
+} from 'react-native-paper';
+import { Mode, Scope, Month } from '../lib/timeScope';
+
+interface Props {
+  scope: Scope;
+  onChange(scope: Scope): void;
+  onOpen?: (mode?: Mode) => void;
+  onClose?: () => void;
+}
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export default function TimeScopePicker({ scope, onChange }: Props) {
+  const now = new Date();
+  const [mode, setMode] = useState<Mode>(scope.mode);
+  const [year, setYear] = useState(scope.mode === 'month' || scope.mode === 'year' ? scope.year : now.getFullYear());
+  const [showCustom, setShowCustom] = useState(false);
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+
+  const handleModeChange = (m: Mode) => {
+    setMode(m);
+    if (m === 'all') {
+      onChange({ mode: 'all' });
+    } else if (m === 'month') {
+      onChange({
+        mode: 'month',
+        year,
+        month: (scope.mode === 'month' ? scope.month : (now.getMonth() + 1)) as Month,
+      });
+    } else if (m === 'year') {
+      onChange({ mode: 'year', year });
+    } else {
+      setShowCustom(true);
+    }
+  };
+
+  const handleMonth = (m: number) => {
+    onChange({ mode: 'month', year, month: m as Month });
+  };
+
+  const handleYear = (y: number) => {
+    setYear(y);
+    onChange({ mode: 'year', year: y });
+  };
+
+  const applyCustom = () => {
+    const startDate = new Date(start);
+    const endDate = new Date(end);
+    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) return;
+    if (startDate.getTime() > endDate.getTime()) return;
+    onChange({ mode: 'custom', startISO: startDate.toISOString(), endISO: endDate.toISOString() });
+    setShowCustom(false);
+  };
+
+  const years: number[] = [];
+  for (let y = now.getFullYear(); y >= 1970; y--) years.push(y);
+
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'white',
+        padding: 8,
+        borderTopLeftRadius: 12,
+        borderTopRightRadius: 12,
+        elevation: 3,
+      }}
+    >
+      <SegmentedButtons
+        value={mode}
+        onValueChange={(v) => handleModeChange(v as Mode)}
+        buttons={[
+          { value: 'month', label: 'Month' },
+          { value: 'year', label: 'Year' },
+          { value: 'all', label: 'All' },
+          { value: 'custom', label: 'Custom' },
+        ]}
+      />
+      {mode === 'month' && (
+        <View style={{ marginTop: 8 }}>
+          <View style={{ flexDirection: 'row', justifyContent: 'center', alignItems: 'center' }}>
+            <IconButton icon="chevron-left" onPress={() => setYear(year - 1)} />
+            <Text>{year}</Text>
+            <IconButton icon="chevron-right" onPress={() => setYear(year + 1)} />
+          </View>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+            {MONTH_LABELS.map((label, idx) => (
+              <Button
+                key={label}
+                mode={scope.mode === 'month' && scope.year === year && scope.month === idx + 1 ? 'contained' : 'text'}
+                style={{ width: '33.33%' }}
+                onPress={() => handleMonth(idx + 1)}
+              >
+                {label}
+              </Button>
+            ))}
+          </View>
+        </View>
+      )}
+      {mode === 'year' && (
+        <ScrollView style={{ maxHeight: 200, marginTop: 8 }}>
+          {years.map((y) => (
+            <List.Item
+              key={y}
+              title={String(y)}
+              onPress={() => handleYear(y)}
+              right={() =>
+                scope.mode === 'year' && scope.year === y ? <List.Icon icon="check" /> : null
+              }
+            />
+          ))}
+        </ScrollView>
+      )}
+      {mode === 'all' && (
+        <View style={{ marginTop: 8 }}>
+          <Text>All entries</Text>
+        </View>
+      )}
+      <Portal>
+        <Modal visible={showCustom} onDismiss={() => setShowCustom(false)}>
+          <View style={{ padding: 16, backgroundColor: 'white' }}>
+            <TextInput placeholder="Start ISO" value={start} onChangeText={setStart} />
+            <TextInput placeholder="End ISO" value={end} onChangeText={setEnd} />
+            <Button onPress={applyCustom}>Apply</Button>
+            <Button onPress={() => setShowCustom(false)}>Cancel</Button>
+          </View>
+        </Modal>
+      </Portal>
+    </View>
+  );
+}

--- a/lib/timeScope.ts
+++ b/lib/timeScope.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+export type Mode = 'month' | 'year' | 'all' | 'custom';
+export type Month = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type Scope =
+  | { mode: 'month'; year: number; month: Month }
+  | { mode: 'year'; year: number }
+  | { mode: 'all' }
+  | { mode: 'custom'; startISO: string; endISO: string };
+
+const isoDate = z.string().refine((d) => !isNaN(Date.parse(d)), {
+  message: 'Invalid date',
+});
+
+export function scopeToRange(scope: Scope): { start: number; end: number } {
+  switch (scope.mode) {
+    case 'month': {
+      const start = new Date(scope.year, scope.month - 1, 1).getTime();
+      const end = new Date(scope.year, scope.month, 1).getTime();
+      return { start, end };
+    }
+    case 'year': {
+      const start = new Date(scope.year, 0, 1).getTime();
+      const end = new Date(scope.year + 1, 0, 1).getTime();
+      return { start, end };
+    }
+    case 'all': {
+      return { start: 0, end: Date.now() };
+    }
+    case 'custom': {
+      const schema = z
+        .object({ startISO: isoDate, endISO: isoDate })
+        .refine(
+          (s) => new Date(s.startISO).getTime() <= new Date(s.endISO).getTime(),
+          { message: 'start must be before end' }
+        );
+      const { startISO, endISO } = schema.parse(scope);
+      return {
+        start: new Date(startISO).getTime(),
+        end: new Date(endISO).getTime(),
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Scope types and converter utilities
- implement TimeScopePicker component for month/year/all/custom
- integrate picker into analytics page and adjust export

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa51fb7748328a42390d37abed0a7