### PR TITLE
feat: enhance time picker

### DIFF
--- a/__tests__/timeScope.test.ts
+++ b/__tests__/timeScope.test.ts
@@ -1,4 +1,4 @@
-import { scopeToRange, Scope } from '../lib/timeScope';
+import { scopeToRange, Scope, scopeToLabel } from '../lib/timeScope';
 
 describe('scopeToRange', () => {
   it('handles month scope', () => {
@@ -42,5 +42,31 @@ describe('scopeToRange', () => {
       endISO: '2024-01-31T00:00:00.000Z',
     };
     expect(() => scopeToRange(scope)).toThrow('start must be before end');
+  });
+});
+
+describe('scopeToLabel', () => {
+  it('formats month scope', () => {
+    const scope: Scope = { mode: 'month', year: 2025, month: 8 };
+    expect(scopeToLabel(scope)).toBe('Aug 2025');
+  });
+
+  it('formats year scope', () => {
+    const scope: Scope = { mode: 'year', year: 2024 };
+    expect(scopeToLabel(scope)).toBe('2024');
+  });
+
+  it('formats all scope', () => {
+    const scope: Scope = { mode: 'all' };
+    expect(scopeToLabel(scope)).toBe('All');
+  });
+
+  it('formats custom scope', () => {
+    const scope: Scope = {
+      mode: 'custom',
+      startISO: '2024-01-01T00:00:00.000Z',
+      endISO: '2024-01-31T00:00:00.000Z',
+    };
+    expect(scopeToLabel(scope)).toBe('2024-01-01–2024-01-31');
   });
 });

--- a/lib/timeScope.ts
+++ b/lib/timeScope.ts
@@ -8,6 +8,21 @@ export type Scope =
   | { mode: 'all' }
   | { mode: 'custom'; startISO: string; endISO: string };
 
+export const MONTH_LABELS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
 const isoDate = z.string().refine((d) => !isNaN(Date.parse(d)), {
   message: 'Invalid date',
 });
@@ -39,6 +54,22 @@ export function scopeToRange(scope: Scope): { start: number; end: number } {
         start: new Date(startISO).getTime(),
         end: new Date(endISO).getTime(),
       };
+    }
+  }
+}
+
+export function scopeToLabel(scope: Scope): string {
+  switch (scope.mode) {
+    case 'month':
+      return `${MONTH_LABELS[scope.month - 1]} ${scope.year}`;
+    case 'year':
+      return String(scope.year);
+    case 'all':
+      return 'All';
+    case 'custom': {
+      const start = new Date(scope.startISO).toISOString().slice(0, 10);
+      const end = new Date(scope.endISO).toISOString().slice(0, 10);
+      return `${start}–${end}`;
     }
   }
 }


### PR DESCRIPTION
## Summary
- add reusable month labels and scopeToLabel helper
- persist analytics time scope and show selection in header
- expand/collapse time picker with accessibility improvements

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baac2158708328affe79ac355c2ddb