### PR TITLE
style: apply monochrome React Native Paper theme

### DIFF
--- a/app/LearnModal.tsx
+++ b/app/LearnModal.tsx
@@ -118,8 +118,12 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
               })}
             </ScrollView>
             <View style={{ marginTop: 12, flexDirection: 'row', justifyContent: 'flex-end' }}>
-              <Button onPress={onDismiss} style={{ marginRight: 8 }}>Cancel</Button>
-              <Button mode="contained" onPress={start} disabled={selected.size === 0}>Learn</Button>
+              <Button mode="outlined" onPress={onDismiss} style={{ marginRight: 8 }}>
+                Cancel
+              </Button>
+              <Button mode="outlined" onPress={start} disabled={selected.size === 0}>
+                Learn
+              </Button>
             </View>
           </View>
         ) : (
@@ -135,7 +139,7 @@ export default function LearnModal({ visible, bank, transactions, onDismiss, onC
             </View>
             <View style={{ marginTop: 12, flexDirection: 'row', justifyContent: 'space-between' }}>
               <Button mode="outlined" onPress={abort}>Abort</Button>
-              <Button mode="contained" onPress={onDismiss} disabled={!completed}>
+              <Button mode="outlined" onPress={onDismiss} disabled={!completed}>
                 {completed ? 'Close' : 'Wait'}
               </Button>
             </View>

--- a/app/ProcessingModal.tsx
+++ b/app/ProcessingModal.tsx
@@ -61,7 +61,7 @@ export default function ProcessingModal({
           }}
         >
           {onAbort && <Button mode="outlined" onPress={onAbort}>Abort</Button>}
-          <Button mode="contained" onPress={onClose} disabled={!done}>
+          <Button mode="outlined" onPress={onClose} disabled={!done}>
             {done ? 'Close' : 'Wait'}
           </Button>
         </View>

--- a/app/TimeScopePicker.tsx
+++ b/app/TimeScopePicker.tsx
@@ -151,11 +151,7 @@ export default function TimeScopePicker({ scope, onChange }: Props) {
                     ? 'check'
                     : undefined
                 }
-                mode={
-                  scope.mode === 'month' && scope.year === year && scope.month === idx + 1
-                    ? 'contained'
-                    : 'text'
-                }
+                mode="outlined"
                 style={{ width: '33.33%', height: 44 }}
                 accessibilityLabel={`${
                   scope.mode === 'month' && scope.year === year && scope.month === idx + 1
@@ -190,10 +186,24 @@ export default function TimeScopePicker({ scope, onChange }: Props) {
       <Portal>
         <Modal visible={showCustom} onDismiss={() => setShowCustom(false)}>
           <View style={{ padding: 16, backgroundColor: 'white' }}>
-            <TextInput placeholder="Start ISO" value={start} onChangeText={setStart} />
-            <TextInput placeholder="End ISO" value={end} onChangeText={setEnd} />
-            <Button onPress={applyCustom}>Apply</Button>
-            <Button onPress={() => setShowCustom(false)}>Cancel</Button>
+            <TextInput
+              mode="outlined"
+              placeholder="Start ISO"
+              value={start}
+              onChangeText={setStart}
+            />
+            <TextInput
+              mode="outlined"
+              placeholder="End ISO"
+              value={end}
+              onChangeText={setEnd}
+            />
+            <Button mode="outlined" onPress={applyCustom}>
+              Apply
+            </Button>
+            <Button mode="outlined" onPress={() => setShowCustom(false)}>
+              Cancel
+            </Button>
           </View>
         </Modal>
       </Portal>

--- a/app/UploadModal.tsx
+++ b/app/UploadModal.tsx
@@ -61,7 +61,13 @@ export default function UploadModal(props: UploadModalProps) {
 
             <List.Section>
               <List.Subheader>File</List.Subheader>
-              <Button mode="contained" icon="file-upload" onPress={onPickFile} style={{ marginBottom: 8 }} accessibilityLabel="Pick PDF file">
+              <Button
+                mode="outlined"
+                icon="file-upload"
+                onPress={onPickFile}
+                style={{ marginBottom: 8 }}
+                accessibilityLabel="Pick PDF file"
+              >
                 Pick PDF file
               </Button>
               <Text style={{ fontSize: 12, color: 'gray', marginBottom: 8 }}>Only PDF files are allowed</Text>
@@ -69,8 +75,12 @@ export default function UploadModal(props: UploadModalProps) {
             </List.Section>
 
             <View style={{ marginTop: 12, flexDirection: 'row', gap: 8 }}>
-              <Button mode="contained" onPress={onUpload} style={{ marginRight: 8 }}>Upload</Button>
-              <Button onPress={onCancelForm}>Cancel</Button>
+              <Button mode="outlined" onPress={onUpload} style={{ marginRight: 8 }}>
+                Upload
+              </Button>
+              <Button mode="outlined" onPress={onCancelForm}>
+                Cancel
+              </Button>
             </View>
           </View>
         </Modal>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { Stack } from "expo-router";
 import { useEffect } from "react";
 import { Provider as PaperProvider } from "react-native-paper";
+import { bwTheme } from "./theme";
 import { initDb } from "../lib/db";
 
 export default function RootLayout() {
@@ -8,7 +9,7 @@ export default function RootLayout() {
     initDb();
   }, []);
   return (
-    <PaperProvider>
+    <PaperProvider theme={bwTheme}>
       <Stack />
     </PaperProvider>
   );

--- a/app/analysis.tsx
+++ b/app/analysis.tsx
@@ -132,10 +132,10 @@ export default function Analysis() {
     <View style={{ flex: 1 }}>
       <Stack.Screen options={{ title: scopeToLabel(scope) }} />
       <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 96 }}>
-        <Button mode="contained" onPress={handleExport} style={{ marginBottom: 16 }}>
+        <Button mode="outlined" onPress={handleExport} style={{ marginBottom: 16 }}>
           Generate CSV export
         </Button>
-        <Card>
+        <Card mode="outlined" style={{ elevation: 0 }}>
           <Card.Content>
             <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
             <View style={{ width: '50%', marginBottom: 12 }}>

--- a/app/analysis/entities.tsx
+++ b/app/analysis/entities.tsx
@@ -65,7 +65,12 @@ export default function AnalysisEntities() {
           const ent = entities.find((e) => e.id === id);
           if (!ent) return null;
           return (
-            <Chip key={id} onPress={() => toggle(id)} style={{ margin: 4 }}>
+            <Chip
+              key={id}
+              mode="outlined"
+              onPress={() => toggle(id)}
+              style={{ margin: 4 }}
+            >
               {ent.label}
             </Chip>
           );
@@ -89,7 +94,7 @@ export default function AnalysisEntities() {
         ))}
       </ScrollView>
       <Button
-        mode="contained"
+        mode="outlined"
         onPress={handleSave}
         style={{ marginTop: 16, marginBottom: 16 }}
       >

--- a/app/bank-accounts/form.tsx
+++ b/app/bank-accounts/form.tsx
@@ -86,7 +86,7 @@ export default function BankAccountForm({ initial, onSubmit, submitLabel }: Prop
         {error ? (
           <Text style={{ color: theme.colors.error, marginBottom: 12 }}>{error}</Text>
         ) : null}
-        <Button mode="contained" onPress={handleSave}>
+        <Button mode="outlined" onPress={handleSave}>
           {submitLabel}
         </Button>
       </View>

--- a/app/bank-accounts/index.tsx
+++ b/app/bank-accounts/index.tsx
@@ -52,7 +52,9 @@ export default function BankAccountsList() {
       >
         <Text style={{ fontSize: 16 }}>{item.label}</Text>
       </TouchableOpacity>
-      <Button onPress={() => confirmDelete(item.id)}>Delete</Button>
+      <Button mode="outlined" onPress={() => confirmDelete(item.id)}>
+        Delete
+      </Button>
     </View>
   );
 
@@ -60,10 +62,7 @@ export default function BankAccountsList() {
     <View style={{ flex: 1 }}>
       <FlatList data={accounts} keyExtractor={(i) => i.id} renderItem={renderItem} />
       <View style={{ padding: 16 }}>
-        <Button
-          mode="contained"
-          onPress={() => router.push('/bank-accounts/new')}
-        >
+        <Button mode="outlined" onPress={() => router.push('/bank-accounts/new')}>
           + Add bank account
         </Button>
       </View>

--- a/app/bank-prompt.tsx
+++ b/app/bank-prompt.tsx
@@ -42,10 +42,10 @@ export default function EditBankPrompt() {
         style={{ marginBottom: 12, height: 128 }}
       />
       <View style={{ flexDirection: 'row', justifyContent: 'flex-end' }}>
-        <Button onPress={() => router.back()} style={{ marginRight: 8 }}>
+        <Button mode="outlined" onPress={() => router.back()} style={{ marginRight: 8 }}>
           Cancel
         </Button>
-        <Button mode="contained" onPress={save}>
+        <Button mode="outlined" onPress={save}>
           Save
         </Button>
       </View>

--- a/app/expense-categories/index.tsx
+++ b/app/expense-categories/index.tsx
@@ -152,7 +152,9 @@ export default function ExpenseCategoriesPage() {
       >
         <Text style={{ fontSize: 16 }}>{item.item.label}</Text>
       </TouchableOpacity>
-      <Button onPress={() => confirmDelete(item.item.id)}>Delete</Button>
+      <Button mode="outlined" onPress={() => confirmDelete(item.item.id)}>
+        Delete
+      </Button>
     </View>
   );
 
@@ -189,12 +191,12 @@ export default function ExpenseCategoriesPage() {
         {error ? (
           <Text style={{ color: theme.colors.error, marginBottom: 12 }}>{error}</Text>
         ) : null}
-        <Button mode="contained" onPress={handleSubmit}>
+        <Button mode="outlined" onPress={handleSubmit}>
           {editingId ? 'Update Category' : 'Add Category'}
         </Button>
         {editingId ? (
           <View style={{ marginTop: 8 }}>
-            <Button onPress={resetForm}>Cancel</Button>
+            <Button mode="outlined" onPress={resetForm}>Cancel</Button>
           </View>
         ) : null}
       </View>
@@ -237,7 +239,9 @@ export default function ExpenseCategoriesPage() {
                 )
               }
             />
-            <Button onPress={() => setParentVisible(false)}>Close</Button>
+            <Button mode="outlined" onPress={() => setParentVisible(false)}>
+              Close
+            </Button>
           </View>
         </View>
       </Modal>

--- a/app/income-savings/index.tsx
+++ b/app/income-savings/index.tsx
@@ -64,12 +64,13 @@ export default function IncomeSavingsPage() {
         ]}
       />
       <TextInput
+        mode="outlined"
         label="Label"
         value={label}
         onChangeText={setLabel}
         style={{ marginVertical: 8 }}
       />
-      <Button mode="contained" onPress={handleAdd} disabled={!label.trim()}>
+      <Button mode="outlined" onPress={handleAdd} disabled={!label.trim()}>
         Add
       </Button>
       <View style={{ marginTop: 24 }}>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -299,20 +299,24 @@ export default function Index() {
           <ScrollView horizontal showsHorizontalScrollIndicator={false}>
             <View style={{ flexDirection: 'row', alignItems: 'center' }}>
               <Chip
-                mode={!filterBankId ? 'flat' : 'outlined'}
-                selected={!filterBankId}
+                mode="outlined"
                 onPress={() => setFilterBankId(null)}
-                style={{ marginRight: 8 }}
+                style={{
+                  marginRight: 8,
+                  backgroundColor: !filterBankId ? '#F5F5F5' : undefined,
+                }}
               >
                 All
               </Chip>
               {bankAccounts.map((b) => (
                 <Chip
                   key={b.id}
-                  mode={filterBankId === b.id ? 'flat' : 'outlined'}
-                  selected={filterBankId === b.id}
+                  mode="outlined"
                   onPress={() => setFilterBankId(filterBankId === b.id ? null : b.id)}
-                  style={{ marginRight: 8 }}
+                  style={{
+                    marginRight: 8,
+                    backgroundColor: filterBankId === b.id ? '#F5F5F5' : undefined,
+                  }}
                 >
                   {b.label}
                 </Chip>
@@ -334,7 +338,11 @@ export default function Index() {
           ) : (
             <ScrollView>
                   {filtered.map((item) => (
-                    <Card key={item.id} style={{ marginBottom: 8 }}>
+                    <Card
+                      key={item.id}
+                      mode="outlined"
+                      style={{ marginBottom: 8, elevation: 0 }}
+                    >
                       <Card.Content>
                         <View style={{ flexDirection: 'row', alignItems: 'center' }}>
                           <TouchableOpacity
@@ -382,15 +390,22 @@ export default function Index() {
               <Text>Are you sure you want to permanently delete this statement?</Text>
             </Dialog.Content>
             <Dialog.Actions>
-              <Button onPress={() => setConfirmVisible(false)}>Cancel</Button>
-              <Button onPress={async () => {
+              <Button mode="outlined" onPress={() => setConfirmVisible(false)}>
+                Cancel
+              </Button>
+              <Button
+                mode="outlined"
+                onPress={async () => {
                 if (deleteTarget) {
                   await deleteStatement(deleteTarget);
                   setDeleteTarget(null);
                   setConfirmVisible(false);
                   await refreshStatements();
                 }
-              }}>Delete</Button>
+              }}
+              >
+                Delete
+              </Button>
             </Dialog.Actions>
           </Dialog>
           <Dialog visible={reprocessConfirm} onDismiss={() => setReprocessConfirm(false)}>
@@ -399,8 +414,12 @@ export default function Index() {
               <Text>Existing transactions will be dropped. Continue?</Text>
             </Dialog.Content>
             <Dialog.Actions>
-              <Button onPress={() => setReprocessConfirm(false)}>Cancel</Button>
-              <Button onPress={async () => {
+              <Button mode="outlined" onPress={() => setReprocessConfirm(false)}>
+                Cancel
+              </Button>
+              <Button
+                mode="outlined"
+                onPress={async () => {
                 if (reprocessTarget) {
                   await reprocessStatement(reprocessTarget.id);
                   await refreshStatements();
@@ -448,7 +467,10 @@ export default function Index() {
                       refreshStatements();
                     });
                 }
-              }}>Reprocess</Button>
+              }}
+              >
+                Reprocess
+              </Button>
             </Dialog.Actions>
           </Dialog>
         </Portal>
@@ -491,16 +513,20 @@ export default function Index() {
         {/* bottom controls: archived toggle and upload button - part of normal layout */}
         <View style={{ marginTop: 12, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
           <Button
-            mode={viewArchived === 'archived' ? 'contained' : 'outlined'}
+            mode="outlined"
             icon={viewArchived === 'archived' ? 'archive-arrow-up' : 'archive'}
             onPress={() => setViewArchived(viewArchived === 'archived' ? 'current' : 'archived')}
             accessibilityLabel={viewArchived === 'archived' ? 'Show current statements' : 'Show archived statements'}
-            style={{ flex: 1, marginRight: 12 }}
+            style={{
+              flex: 1,
+              marginRight: 12,
+              backgroundColor: viewArchived === 'archived' ? '#F5F5F5' : 'transparent',
+            }}
           >
             {viewArchived === 'archived' ? 'Archived' : 'Current'}
           </Button>
 
-          <Button mode="contained" icon="upload" onPress={openUploadModal}>
+          <Button mode="outlined" icon="upload" onPress={openUploadModal}>
             Upload
           </Button>
         </View>

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -35,20 +35,20 @@ function ManageButtons() {
         Manage categories
       </Text>
       <Button
-        mode="contained"
+        mode="outlined"
         onPress={() => router.push('/bank-accounts')}
         style={{ marginBottom: 8 }}
       >
         Manage bank accounts
       </Button>
       <Button
-        mode="contained"
+        mode="outlined"
         onPress={() => router.push('/expense-categories')}
         style={{ marginBottom: 8 }}
       >
         Manage expense categories
       </Button>
-      <Button mode="contained" onPress={() => router.push('/income-savings')}>
+      <Button mode="outlined" onPress={() => router.push('/income-savings')}>
         Manage income & savings
       </Button>
     </View>
@@ -151,7 +151,7 @@ const handleRemove = () => {
               {error}
             </Text>
           ) : null}
-          <Button mode="contained" onPress={handleSave}>
+          <Button mode="outlined" onPress={handleSave}>
             {hasKey ? 'Save new key' : 'Save key'}
           </Button>
         </View>
@@ -166,11 +166,11 @@ const handleRemove = () => {
         <Text style={{ marginBottom: 16 }}>
           Key saved • Last updated {formatDate(updatedAt)}
         </Text>
-        <Button mode="contained" onPress={() => setEditing(true)}>
+        <Button mode="outlined" onPress={() => setEditing(true)}>
           Replace key
         </Button>
         <View style={{ height: 8 }} />
-        <Button onPress={handleRemove}>Remove key</Button>
+        <Button mode="outlined" onPress={handleRemove}>Remove key</Button>
       </View>
     );
   };
@@ -189,7 +189,7 @@ const handleRemove = () => {
         onChangeText={setPrompt}
         style={{ marginBottom: 8 }}
       />
-      <Button onPress={() => Keyboard.dismiss()} style={{ marginBottom: 8 }}>
+      <Button mode="outlined" onPress={() => Keyboard.dismiss()} style={{ marginBottom: 8 }}>
         Dismiss keyboard
       </Button>
       <Divider style={{ marginVertical: 16 }} />
@@ -217,7 +217,7 @@ const handleRemove = () => {
       <Text style={{ fontSize: 12, color: 'gray', marginBottom: 8 }}>
         This will be the default shared value for all entries created.
       </Text>
-      <Button onPress={handlePromptSave}>Save settings</Button>
+      <Button mode="outlined" onPress={handlePromptSave}>Save settings</Button>
       <Divider style={{ marginVertical: 16 }} />
       {renderKeySection()}
     </ScrollView>

--- a/app/statements/[id].tsx
+++ b/app/statements/[id].tsx
@@ -418,7 +418,7 @@ export default function StatementTransactions() {
                   const signed = isBankSender ? `- ${nf.format(displayAmountVal)}` : isBankRecipient ? `+ ${nf.format(displayAmountVal)}` : nf.format(displayAmountVal);
                   return (
                     <View key={item.id} style={{ marginBottom: 12 }}>
-                      <Card>
+                      <Card mode="outlined" style={{ elevation: 0 }}>
                         <Card.Content>
                           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
                             <View style={{ marginRight: 8 }}>
@@ -479,7 +479,9 @@ export default function StatementTransactions() {
             <View style={{ padding: 8 }}>
               <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
                 <Text style={{ fontSize: 18, fontWeight: '700' }}>Edit transaction</Text>
-                <Button onPress={markEditingReviewed}>Mark reviewed</Button>
+                <Button mode="outlined" onPress={markEditingReviewed}>
+                  Mark reviewed
+                </Button>
               </View>
               <ScrollView>
                 <View style={{ marginTop: 12 }}>
@@ -557,7 +559,7 @@ export default function StatementTransactions() {
                 <View style={{ marginTop: 12 }}>
                   <Text>Sender</Text>
                   <Button
-                    mode="text"
+                    mode="outlined"
                     onPress={() => openEntityPicker(editing.txn.id, 'sender')}
                     style={{ alignSelf: 'flex-start', marginTop: 6 }}
                   >
@@ -568,7 +570,7 @@ export default function StatementTransactions() {
                 <View style={{ marginTop: 12 }}>
                   <Text>Recipient</Text>
                   <Button
-                    mode="text"
+                    mode="outlined"
                     onPress={() => openEntityPicker(editing.txn.id, 'recipient')}
                     style={{ alignSelf: 'flex-start', marginTop: 6 }}
                   >

--- a/app/theme.ts
+++ b/app/theme.ts
@@ -1,0 +1,34 @@
+import { MD3LightTheme } from 'react-native-paper';
+
+export const bwTheme = {
+  ...MD3LightTheme,
+  colors: {
+    ...MD3LightTheme.colors,
+    primary: '#000000',
+    onPrimary: '#FFFFFF',
+    secondary: '#000000',
+    onSecondary: '#FFFFFF',
+
+    background: '#FFFFFF',
+    surface: '#FFFFFF',
+    onSurface: '#000000',
+
+    outline: '#000000',
+    outlineVariant: '#808080',
+
+    surfaceVariant: '#F5F5F5',
+    onSurfaceVariant: '#000000',
+
+    elevation: {
+      level0: 'transparent',
+      level1: '#FFFFFF',
+      level2: '#FFFFFF',
+      level3: '#FFFFFF',
+      level4: '#FFFFFF',
+      level5: '#FFFFFF',
+    },
+  },
+  roundness: 4,
+} as const;
+
+export type BWTheme = typeof bwTheme;


### PR DESCRIPTION
## Summary
- add black and white React Native Paper theme and wire it into the app
- switch buttons, chips, cards and inputs to outlined look with minimal gray backgrounds

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bab02fd9688328a64435e4814a784a