### PR TITLE
Fix app bar titles for index and settings

### DIFF
--- a/app/analysis.tsx
+++ b/app/analysis.tsx
@@ -17,7 +17,11 @@ import TimeScopePicker from './TimeScopePicker';
 import { Scope, scopeToRange, Month, scopeToLabel } from '../lib/timeScope';
 import * as SecureStore from 'expo-secure-store';
 
-export default function Analysis() {
+export default function Analysis({
+  onTitleChange,
+}: {
+  onTitleChange?: (title: string) => void;
+}) {
   const router = useRouter();
   const { income: incomeParam, savings: savingsParam } =
     useLocalSearchParams<{
@@ -43,6 +47,11 @@ export default function Analysis() {
   const [selectedSavings, setSelectedSavings] = useState<string[]>([]);
   const [reviewedCount, setReviewedCount] = useState(0);
   const [bankSummary, setBankSummary] = useState<BankTransactionSummary[]>([]);
+  const title = scopeToLabel(scope);
+
+  useEffect(() => {
+    onTitleChange?.(title);
+  }, [title, onTitleChange]);
 
   useEffect(() => {
     (async () => {
@@ -130,7 +139,7 @@ export default function Analysis() {
 
   return (
     <View style={{ flex: 1 }}>
-      <Stack.Screen options={{ title: scopeToLabel(scope) }} />
+      {!onTitleChange && <Stack.Screen options={{ title }} />}
       <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 96 }}>
         <Button mode="outlined" onPress={handleExport} style={{ marginBottom: 16 }}>
           Generate CSV export

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -96,10 +96,11 @@ function ActionMenu({
   );
 }
 
-export default function Index() {
-  const router = useRouter();
-  const [navIndex, setNavIndex] = useState(0);
-  const [navRoutes] = useState([
+  export default function Index() {
+    const router = useRouter();
+    const [navIndex, setNavIndex] = useState(0);
+    const [analysisTitle, setAnalysisTitle] = useState('Analysis');
+    const [navRoutes] = useState([
     {
       key: 'import',
       title: 'Import',
@@ -564,30 +565,47 @@ export default function Index() {
     </View>
   );
 
-  const AnalysisRoute = () => (
-    <View style={{ flex: 1 }}>
-      <Analysis />
-    </View>
-  );
+    const AnalysisRoute = () => (
+      <View style={{ flex: 1 }}>
+        <Analysis onTitleChange={setAnalysisTitle} />
+      </View>
+    );
 
-  const renderScene = BottomNavigation.SceneMap({
-    import: ImportRoute,
-    analysis: AnalysisRoute,
-    settings: SettingsRoute,
-  });
+    const renderScene = ({
+      route,
+    }: {
+      route: { key: string };
+      jumpTo: (key: string) => void;
+    }) => {
+      switch (route.key) {
+        case 'import':
+          return <ImportRoute />;
+        case 'analysis':
+          return <AnalysisRoute />;
+        case 'settings':
+          return <SettingsRoute />;
+        default:
+          return null;
+      }
+    };
 
   return (
     <>
-      <Stack.Screen
-        options={{
-          title: navIndex === 0 ? 'Transactions' : navRoutes[navIndex].title,
-        }}
-      />
-      <BottomNavigation
-        navigationState={{ index: navIndex, routes: navRoutes }}
-        onIndexChange={setNavIndex}
-        renderScene={renderScene}
-      />
+        <Stack.Screen
+          options={{
+            title:
+              navIndex === 0
+                ? 'Transactions'
+                : navIndex === 1
+                ? analysisTitle
+                : navRoutes[navIndex].title,
+          }}
+        />
+        <BottomNavigation
+          navigationState={{ index: navIndex, routes: navRoutes }}
+          onIndexChange={setNavIndex}
+          renderScene={renderScene}
+        />
       <Snackbar
         visible={toast.visible}
         onDismiss={() => setToast({ visible: false, message: '' })}


### PR DESCRIPTION
## Summary
- keep index, settings headers independent of analytics time scope
- derive analytics header title via callback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c123a129ec832899c0a9c287e87ddd