### PR TITLE
fix: keep analytics title and show timeframe in nav

### DIFF
--- a/__tests__/nav-title.test.ts
+++ b/__tests__/nav-title.test.ts
@@ -11,8 +11,8 @@ describe('navTitleForIndex', () => {
     expect(navTitleForIndex(0, 'Any', routes)).toBe('Transactions');
   });
 
-  it('returns analysis title for second tab', () => {
-    expect(navTitleForIndex(1, 'March', routes)).toBe('March');
+  it('returns fixed title for analysis tab', () => {
+    expect(navTitleForIndex(1, 'March', routes)).toBe('Analysis');
   });
 
   it('falls back to route title for others', () => {

--- a/app/analysis.tsx
+++ b/app/analysis.tsx
@@ -47,11 +47,11 @@ export default function Analysis({
   const [selectedSavings, setSelectedSavings] = useState<string[]>([]);
   const [reviewedCount, setReviewedCount] = useState(0);
   const [bankSummary, setBankSummary] = useState<BankTransactionSummary[]>([]);
-  const title = scopeToLabel(scope);
+  const timeframeLabel = scopeToLabel(scope);
 
   useEffect(() => {
-    onTitleChange?.(title);
-  }, [title, onTitleChange]);
+    onTitleChange?.(timeframeLabel);
+  }, [timeframeLabel, onTitleChange]);
 
   useEffect(() => {
     (async () => {
@@ -139,7 +139,7 @@ export default function Analysis({
 
   return (
     <View style={{ flex: 1 }}>
-      {!onTitleChange && <Stack.Screen options={{ title }} />}
+      {!onTitleChange && <Stack.Screen options={{ title: 'Analysis' }} />}
       <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 96 }}>
         <Button mode="outlined" onPress={handleExport} style={{ marginBottom: 16 }}>
           Generate CSV export

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -125,8 +125,8 @@ export default function Index() {
   const router = useRouter();
   const navigation = useNavigation();
   const [navIndex, setNavIndex] = useState(0);
-  const [analysisTitle, setAnalysisTitle] = useState('Analysis');
-  const [navRoutes] = useState([
+  const [analysisLabel, setAnalysisLabel] = useState('Analysis');
+  const [navRoutes, setNavRoutes] = useState([
     {
       key: 'import',
       title: 'Import',
@@ -163,7 +163,15 @@ export default function Index() {
   const [progress, setProgress] = useState<Record<string, number>>({});
   const showToast = (message: string) => setToast({ visible: true, message });
 
-  const title = navTitleForIndex(navIndex, analysisTitle, navRoutes);
+  const title = navTitleForIndex(navIndex, analysisLabel, navRoutes);
+
+  useEffect(() => {
+    setNavRoutes((routes) => {
+      const updated = [...routes];
+      updated[1] = { ...routes[1], title: analysisLabel };
+      return updated;
+    });
+  }, [analysisLabel]);
 
   useEffect(() => {
     navigation.setOptions({ title });
@@ -599,7 +607,7 @@ export default function Index() {
 
     const AnalysisRoute = () => (
       <View style={{ flex: 1 }}>
-        <Analysis onTitleChange={setAnalysisTitle} />
+        <Analysis onTitleChange={setAnalysisLabel} />
       </View>
     );
 

--- a/lib/navTitle.ts
+++ b/lib/navTitle.ts
@@ -1,10 +1,10 @@
 export const navTitleForIndex = (
   index: number,
-  analysisTitle: string,
+  _analysisTitle: string,
   routes: { title: string }[],
 ): string =>
   index === 0
     ? 'Transactions'
     : index === 1
-    ? analysisTitle
+    ? 'Analysis'
     : routes[index]?.title ?? '';


### PR DESCRIPTION
## Summary
- keep Analysis page title fixed in app bar
- update bottom navigation label with selected timeframe
- adjust nav title logic and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c154aba3ec8328a8393a378757f902