### PR TITLE
Fix analysis navigation label and timeframe picker

### DIFF
--- a/__tests__/nav-title.test.ts
+++ b/__tests__/nav-title.test.ts
@@ -11,8 +11,8 @@ describe('navTitleForIndex', () => {
     expect(navTitleForIndex(0, 'Any', routes)).toBe('Transactions');
   });
 
-  it('returns fixed title for analysis tab', () => {
-    expect(navTitleForIndex(1, 'March', routes)).toBe('Analysis');
+  it('returns provided title for analysis tab', () => {
+    expect(navTitleForIndex(1, 'March', routes)).toBe('March');
   });
 
   it('falls back to route title for others', () => {

--- a/app/TimeScopePicker.tsx
+++ b/app/TimeScopePicker.tsx
@@ -128,10 +128,10 @@ export default function TimeScopePicker({ scope, onChange }: Props) {
         value={mode}
         onValueChange={(v) => handleModeChange(v as Mode)}
         buttons={[
-          { value: 'month', label: 'Month' },
-          { value: 'year', label: 'Year' },
-          { value: 'all', label: 'All' },
-          { value: 'custom', label: 'Custom' },
+          { value: 'month', label: 'Month', onPress: () => handleModeChange('month') },
+          { value: 'year', label: 'Year', onPress: () => handleModeChange('year') },
+          { value: 'all', label: 'All', onPress: () => handleModeChange('all') },
+          { value: 'custom', label: 'Custom', onPress: () => handleModeChange('custom') },
         ]}
       />
       {open && mode === 'month' && (

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -126,7 +126,7 @@ export default function Index() {
   const navigation = useNavigation();
   const [navIndex, setNavIndex] = useState(0);
   const [analysisLabel, setAnalysisLabel] = useState('Analysis');
-  const [navRoutes, setNavRoutes] = useState([
+  const navRoutes = [
     {
       key: 'import',
       title: 'Import',
@@ -145,7 +145,7 @@ export default function Index() {
       focusedIcon: 'cog',
       unfocusedIcon: 'cog-outline',
     },
-  ]);
+  ];
   const [statements, setStatements] = useState<StatementMeta[]>([]);
   const [banks, setBanks] = useState<Entity[]>([]);
   const [selectedBank, setSelectedBank] = useState<string | null>(null);
@@ -164,14 +164,6 @@ export default function Index() {
   const showToast = (message: string) => setToast({ visible: true, message });
 
   const title = navTitleForIndex(navIndex, analysisLabel, navRoutes);
-
-  useEffect(() => {
-    setNavRoutes((routes) => {
-      const updated = [...routes];
-      updated[1] = { ...routes[1], title: analysisLabel };
-      return updated;
-    });
-  }, [analysisLabel]);
 
   useEffect(() => {
     navigation.setOptions({ title });

--- a/lib/navTitle.ts
+++ b/lib/navTitle.ts
@@ -1,10 +1,10 @@
 export const navTitleForIndex = (
   index: number,
-  _analysisTitle: string,
+  analysisTitle: string,
   routes: { title: string }[],
 ): string =>
   index === 0
     ? 'Transactions'
     : index === 1
-    ? 'Analysis'
+    ? analysisTitle
     : routes[index]?.title ?? '';


### PR DESCRIPTION
## Summary
- Keep analytics tab label fixed in bottom navigation and update screen title with current timeframe
- Ensure segmented timeframe buttons open drawer even when reselecting current mode

## Testing
- `npm ci`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c15d106404832894a81def0b8645e3