### PR TITLE
Fix persistent analytics title

### DIFF
--- a/__tests__/nav-title.test.ts
+++ b/__tests__/nav-title.test.ts
@@ -1,0 +1,11 @@
+import { navTitleForIndex } from '../lib/navigation';
+
+test('navTitleForIndex maps indexes to titles', () => {
+  expect(navTitleForIndex(0)).toBe('Transactions');
+  expect(navTitleForIndex(1)).toBe('Analysis');
+  expect(navTitleForIndex(2)).toBe('Settings');
+});
+
+test('navTitleForIndex returns empty string for unknown index', () => {
+  expect(navTitleForIndex(5)).toBe('');
+});

--- a/app/analysis.tsx
+++ b/app/analysis.tsx
@@ -17,7 +17,11 @@ import { listEntities } from '../lib/entities';
 import { Month, Scope, scopeToRange } from '../lib/timeScope';
 import TimeScopePicker from './TimeScopePicker';
 
-export default function Analysis() {
+export default function Analysis({
+  showTitle = true,
+}: {
+  showTitle?: boolean;
+}) {
   const router = useRouter();
   const { income: incomeParam, savings: savingsParam } =
     useLocalSearchParams<{
@@ -132,7 +136,7 @@ export default function Analysis() {
 
   return (
     <View style={{ flex: 1 }}>
-      <Stack.Screen options={{ title: 'Analysis' }} />
+      {showTitle && <Stack.Screen options={{ title: 'Analysis' }} />}
       <ScrollView contentContainerStyle={{ padding: 16, paddingBottom: 96 }}>
         <Text style={{ marginBottom: 16 }}>
           Selected {reviewedCount} reviewed transactions for this timeframe

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -39,11 +39,7 @@ import {
 import Analysis from './analysis';
 import Settings from './settings';
 import UploadModal from './UploadModal';
-
-const navigationTitles = ['Transactions', 'Analysis', 'Settings'] as const;
-const navTitleForIndex = (
-  index: number
-): string =>    navigationTitles[index] ?? '';
+import { navTitleForIndex } from '../lib/navigation';
 
 
 function StatusRow({ item }: { item: StatementMeta }) {
@@ -603,7 +599,7 @@ export default function Index() {
 
     const AnalysisRoute = () => (
       <View style={{ flex: 1 }}>
-        <Analysis />
+        <Analysis showTitle={false} />
       </View>
     );
 

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,0 +1,4 @@
+export const navigationTitles = ['Transactions', 'Analysis', 'Settings'] as const;
+
+export const navTitleForIndex = (index: number): string =>
+  navigationTitles[index] ?? '';


### PR DESCRIPTION
## Summary
- allow disabling Analysis screen title to avoid overrides
- centralize navigation titles and add tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2db4315bc8328ad3ddd7abddc3aa6