### PR TITLE
feat(settings): add spacing below OpenAI key field

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -176,6 +176,7 @@ export default function Settings() {
           <Button mode="outlined" onPress={handleSave}>
             {hasKey ? 'Save new key' : 'Save key'}
           </Button>
+          <View style={{ height: 200 }} />
         </View>
       );
     }


### PR DESCRIPTION
## Summary
- add spacer after OpenAI API key input so keyboard doesn't cover it

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6ce36260883289ebffb300944d479