### PR TITLE
chore: improve form keyboard UX

### DIFF
--- a/app/bank-accounts/form.tsx
+++ b/app/bank-accounts/form.tsx
@@ -1,6 +1,14 @@
-import { useState } from 'react';
-import { View } from 'react-native';
-import { Button, List, Menu, Text, TextInput, useTheme } from 'react-native-paper';
+import { useRef, useState } from 'react';
+import {
+  Keyboard,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button, Menu, Text, TextInput, useTheme } from 'react-native-paper';
 import { SUPPORTED_CURRENCIES } from '../../lib/currencies';
 import { BankAccountInput, bankAccountSchema } from '../../lib/entities';
 
@@ -19,6 +27,9 @@ export default function BankAccountForm({ initial, onSubmit, submitLabel }: Prop
   const [error, setError] = useState<string>('');
   const [menuVisible, setMenuVisible] = useState(false);
   const theme = useTheme();
+  const insets = useSafeAreaInsets();
+  const labelRef = useRef<any>(null);
+  const promptRef = useRef<any>(null);
 
   const handleSave = async () => {
     const input: BankAccountInput = {
@@ -36,60 +47,86 @@ export default function BankAccountForm({ initial, onSubmit, submitLabel }: Prop
   };
 
   return (
-    <View style={{ flex: 1, padding: 16 }}>
-      <List.Section>
-        <List.Subheader>Bank details</List.Subheader>
-        <Text style={{ marginBottom: 4 }}>Label</Text>
-        <TextInput
-          mode="outlined"
-          value={label}
-          onChangeText={setLabel}
-          style={{ marginBottom: 12 }}
-        />
-        <Text style={{ marginBottom: 4 }}>Prompt</Text>
-        <TextInput
-          mode="outlined"
-          value={prompt}
-          onChangeText={setPrompt}
-          multiline
-          style={{ marginBottom: 4, height: 128 }}
-        />
-        <Text style={{ marginBottom: 12, color: theme.colors.onSurfaceVariant }}>
-          List specifics that are important to consider for the processing of the
-          file.
-        </Text>
-        <Text style={{ marginBottom: 4 }}>Currency</Text>
-        <Menu
-          visible={menuVisible}
-          onDismiss={() => setMenuVisible(false)}
-          style={{ maxHeight: 300 }}
-          anchor={
-            <Button mode="outlined" onPress={() => setMenuVisible(true)} style={{ marginBottom: 12 }}>
-              {currency}
-            </Button>
-          }
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
+        <ScrollView
+          keyboardDismissMode="on-drag"
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{
+            flexGrow: 1,
+            padding: 16,
+            paddingBottom: insets.bottom + 16,
+          }}
         >
-          {SUPPORTED_CURRENCIES.map((c) => (
-            <Menu.Item
-              key={c}
-              onPress={() => {
-                setCurrency(c);
-                setMenuVisible(false);
-              }}
-              title={c}
-            />
-          ))}
-        </Menu>
-      </List.Section>
+          <Text style={{ marginBottom: 4 }}>Label</Text>
+          <TextInput
+            mode="outlined"
+            value={label}
+            onChangeText={setLabel}
+            style={{ marginBottom: 12 }}
+            ref={labelRef}
+            returnKeyType="next"
+            blurOnSubmit={false}
+            onSubmitEditing={() => promptRef.current?.focus()}
+          />
+          <Text style={{ marginBottom: 4 }}>Prompt</Text>
+          <TextInput
+            mode="outlined"
+            value={prompt}
+            onChangeText={setPrompt}
+            multiline
+            style={{ marginBottom: 4, height: 128 }}
+            ref={promptRef}
+            returnKeyType="done"
+            blurOnSubmit
+            onSubmitEditing={Keyboard.dismiss}
+          />
+          <Text style={{ marginBottom: 12, color: theme.colors.onSurfaceVariant }}>
+            List specifics that are important to consider for the processing of
+            the file.
+          </Text>
+          <Text style={{ marginBottom: 4 }}>Currency</Text>
+          <Menu
+            visible={menuVisible}
+            onDismiss={() => setMenuVisible(false)}
+            style={{ maxHeight: 300 }}
+            anchor={
+              <Button
+                mode="outlined"
+                onPress={() => setMenuVisible(true)}
+                style={{ marginBottom: 12 }}
+              >
+                {currency}
+              </Button>
+            }
+          >
+            {SUPPORTED_CURRENCIES.map((c) => (
+              <Menu.Item
+                key={c}
+                onPress={() => {
+                  setCurrency(c);
+                  setMenuVisible(false);
+                }}
+                title={c}
+              />
+            ))}
+          </Menu>
 
-      <View style={{ marginTop: 12 }}>
-        {error ? (
-          <Text style={{ color: theme.colors.error, marginBottom: 12 }}>{error}</Text>
-        ) : null}
-        <Button mode="outlined" onPress={handleSave}>
-          {submitLabel}
-        </Button>
-      </View>
-    </View>
+          <View style={{ marginTop: 12 }}>
+            {error ? (
+              <Text style={{ color: theme.colors.error, marginBottom: 12 }}>
+                {error}
+              </Text>
+            ) : null}
+            <Button mode="outlined" onPress={handleSave}>
+              {submitLabel}
+            </Button>
+          </View>
+        </ScrollView>
+      </TouchableWithoutFeedback>
+    </KeyboardAvoidingView>
   );
 }


### PR DESCRIPTION
## Summary
- remove unused "Bank details" copy from bank account form
- add keyboard-safe ScrollViews with background tap dismissal for bank account and expense category screens
- chain input focus and keep primary actions visible with safe-area padding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6cf1c8d748328aee9a8a199043880