### PR TITLE
feat: seed default bank account on database initialization

### DIFF
--- a/__tests__/analytics-export.test.ts
+++ b/__tests__/analytics-export.test.ts
@@ -4,12 +4,14 @@ import { createStatement } from '../lib/statements';
 import { createExpenseCategory, createEntity } from '../lib/entities';
 import { createTransaction } from '../lib/transactions';
 import { exportReviewedTransactionsToCsv } from '../lib/analytics';
+import { initDb } from '../lib/db';
 import sqliteMock from '../test-utils/sqliteMock';
 
 describe('exportReviewedTransactionsToCsv', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     // @ts-ignore
     sqliteMock.__reset();
+    await initDb();
   });
 
   it('exports reviewed transactions with entity keys', async () => {

--- a/__tests__/analytics.test.ts
+++ b/__tests__/analytics.test.ts
@@ -4,12 +4,14 @@ import { createStatement } from '../lib/statements';
 import { createExpenseCategory, createEntity } from '../lib/entities';
 import { createTransaction } from '../lib/transactions';
 import { summarizeExpensesByParent, computeKeyMetrics, summarizeReviewedTransactionsByBank } from '../lib/analytics';
+import { initDb } from '../lib/db';
 import sqliteMock from '../test-utils/sqliteMock';
 
 describe('analytics', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     // @ts-ignore
     sqliteMock.__reset();
+    await initDb();
   });
 
   it('summarizes expenses by top-level parent', async () => {
@@ -323,9 +325,10 @@ describe('analytics', () => {
     });
 
     const res = await summarizeReviewedTransactionsByBank(now - 2000, now);
-    expect(res).toEqual([
-      { bankId: bank1.id, bankLabel: 'Bank1', count: 1, total: 100 },
-      { bankId: bank2.id, bankLabel: 'Bank2', count: 0, total: 0 },
-    ]);
+    // Find the results for Bank1 and Bank2 (Main is also seeded by initDb)
+    const bank1Result = res.find((r) => r.bankLabel === 'Bank1');
+    const bank2Result = res.find((r) => r.bankLabel === 'Bank2');
+    expect(bank1Result).toEqual({ bankId: bank1.id, bankLabel: 'Bank1', count: 1, total: 100 });
+    expect(bank2Result).toEqual({ bankId: bank2.id, bankLabel: 'Bank2', count: 0, total: 0 });
   });
 });

--- a/__tests__/entities.test.ts
+++ b/__tests__/entities.test.ts
@@ -36,6 +36,14 @@ test('seeds default income and savings categories', async () => {
   expect(savings.find((c) => c.label === 'General')).toBeTruthy();
 });
 
+test('seeds default bank account', async () => {
+  const banks = await listBankAccounts();
+  const mainBank = banks.find((b) => b.label === 'Main');
+  expect(mainBank).toBeTruthy();
+  expect(mainBank?.category).toBe('bank');
+  expect(mainBank?.currency).toBe('USD');
+});
+
 test('create, update, delete bank account', async () => {
   const created = await createBankAccount({
     label: 'Checking',
@@ -55,7 +63,9 @@ test('create, update, delete bank account', async () => {
   expect(updated?.currency).toBe('EUR');
   await deleteBankAccount(created.id);
   const list = await listBankAccounts();
-  expect(list.length).toBe(0);
+  // Default "Main" bank account is seeded on initDb, so expect 1 remaining
+  expect(list.length).toBe(1);
+  expect(list[0].label).toBe('Main');
 });
 
 test('create bank account without prompt', async () => {

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -211,15 +211,16 @@ export async function summarizeReviewedTransactionsByBank(
 
   // Update with actual data
   rows.forEach((r) => {
+    const existing = summary.get(String(r.bank_id));
     summary.set(String(r.bank_id), {
       bankId: String(r.bank_id),
-      bankLabel: r.bank_label,
+      bankLabel: r.bank_label || existing?.bankLabel || '',
       count: r.count,
       total: r.total,
     });
   });
 
-  return Array.from(summary.values()).sort((a, b) => a.bankLabel.localeCompare(b.bankLabel));
+  return Array.from(summary.values()).sort((a, b) => (a.bankLabel || '').localeCompare(b.bankLabel || ''));
 }
 
 function toCamel(parts: string[]): string {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -289,4 +289,22 @@ async function seedDefaultCategories(db: SQLite.SQLiteDatabase) {
       );
     }
   }
+
+  // Seed default bank account
+  const bankExisting = await db.getFirstAsync<{ count: number }>(
+    'SELECT COUNT(*) as count FROM entities WHERE category=?',
+    'bank'
+  );
+  if (!bankExisting || bankExisting.count === 0) {
+    await db.runAsync(
+      'INSERT INTO entities (label, category, prompt, parent_id, currency, created_at, updated_at) VALUES (?,?,?,?,?,?,?)',
+      'Main',
+      'bank',
+      '',
+      null,
+      'USD',
+      now,
+      now
+    );
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4113,7 +4113,7 @@
       "version": "19.1.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.17.tgz",
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5969,7 +5969,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",


### PR DESCRIPTION
Add a default "Main" bank account that is seeded when the database is
initialized, similar to how default expense, income, and savings categories
are seeded. This ensures users have at least one bank account available
on cold start.

Also includes:
- Test updates to account for the new default bank account
- Improved mock support for analytics queries with proper filtering
- Defensive handling for undefined bank labels in analytics